### PR TITLE
chore: ERC20OverwriteFactory - remove get_geth_overwrites

### DIFF
--- a/src/protocol/vm/erc20_overwrite_factory.rs
+++ b/src/protocol/vm/erc20_overwrite_factory.rs
@@ -1,26 +1,14 @@
-// TODO: remove skip for clippy dead_code check
-#![allow(dead_code)]
-use std::{collections::HashMap, path::Path};
+use std::collections::HashMap;
 
 use ethers::{abi::Address, types::U256};
 use revm::primitives::Address as rAddress;
 
 use crate::{
     evm::ContractCompiler,
-    protocol::vm::{
-        errors::FileError,
-        utils::{get_contract_bytecode, get_storage_slot_index_at_key, SlotId},
-    },
+    protocol::vm::utils::{get_storage_slot_index_at_key, SlotId},
 };
 
 use super::utils::ERC20Slots;
-
-pub struct GethOverwrite {
-    /// the formatted overwrites
-    pub state_diff: HashMap<String, String>,
-    /// the bytecode as a string
-    pub code: String,
-}
 
 pub type Overwrites = HashMap<SlotId, U256>;
 
@@ -62,6 +50,8 @@ impl ERC20OverwriteFactory {
             .insert(storage_index, allowance);
     }
 
+    // TODO: remove skip when we check if this is needed
+    #[allow(dead_code)]
     pub fn set_total_supply(&mut self, supply: U256) {
         self.overwrites
             .insert(self.total_supply_slot, supply);
@@ -71,44 +61,6 @@ impl ERC20OverwriteFactory {
         let mut result = HashMap::new();
         result.insert(self.token_address, self.overwrites.clone());
         result
-    }
-
-    pub fn get_geth_overwrites(&self) -> Result<HashMap<rAddress, GethOverwrite>, FileError> {
-        let mut formatted_overwrites = HashMap::new();
-
-        for (key, val) in &self.overwrites {
-            let mut key_bytes = [0u8; 32];
-            key.to_big_endian(&mut key_bytes);
-            let hex_key = hex::encode(key_bytes);
-
-            let mut value_bytes = [0u8; 32];
-            val.to_big_endian(&mut value_bytes);
-            let hex_val = format!("0x{:0>64}", hex::encode(value_bytes));
-
-            formatted_overwrites.insert(hex_key, hex_val);
-        }
-
-        let erc20_abi_path = Path::new(file!())
-            .parent()
-            .ok_or_else(|| {
-                FileError::Structure(
-                    "Failed to obtain parent directory of current file.".to_string(),
-                )
-            })?
-            .join("assets")
-            .join("ERC20.abi");
-
-        let contract_bytecode =
-            get_contract_bytecode(erc20_abi_path.to_str().ok_or_else(|| {
-                FileError::FilePath("Failed to convert file path to string.".to_string())
-            })?)?;
-
-        let code = format!("0x{}", hex::encode(contract_bytecode.bytes()));
-
-        let mut result = HashMap::new();
-        result.insert(self.token_address, GethOverwrite { state_diff: formatted_overwrites, code });
-
-        Ok(result)
     }
 }
 
@@ -182,39 +134,5 @@ mod tests {
         assert!(overwrites.contains_key(&factory.token_address));
         assert_eq!(overwrites[&factory.token_address].len(), 1);
         assert_eq!(overwrites[&factory.token_address][&factory.total_supply_slot], supply);
-    }
-
-    #[test]
-    fn test_get_geth_overwrites() {
-        let mut factory = setup_factory();
-
-        let storage_slot = SlotId::from(1);
-        let val = U256::from(123456);
-        factory
-            .overwrites
-            .insert(storage_slot, val);
-
-        let result = factory
-            .get_geth_overwrites()
-            .expect("Failed to get geth overwrites");
-
-        assert_eq!(result.len(), 1);
-
-        let geth_overwrite = result
-            .get(&factory.token_address)
-            .expect("Missing token address");
-        assert_eq!(geth_overwrite.state_diff.len(), 1);
-
-        let expected_key =
-            String::from("0000000000000000000000000000000000000000000000000000000000000001");
-        let expected_val =
-            String::from("0x000000000000000000000000000000000000000000000000000000000001e240");
-        assert_eq!(
-            geth_overwrite
-                .state_diff
-                .get(&expected_key),
-            Some(&expected_val)
-        );
-        assert_eq!(geth_overwrite.code.len(), 8752);
     }
 }


### PR DESCRIPTION
because it's unused and unnecessary.
Also remove skip for dead code check. Nothing should be dead now.