### PR TITLE
chore: Make EngineDatabaseInterface rely on DatabaseRef

### DIFF
--- a/src/evm/engine_db_interface.rs
+++ b/src/evm/engine_db_interface.rs
@@ -3,9 +3,10 @@ use std::collections::HashMap;
 use revm::{
     precompile::Address,
     primitives::{AccountInfo, U256 as rU256},
+    DatabaseRef,
 };
 
-pub trait EngineDatabaseInterface {
+pub trait EngineDatabaseInterface: DatabaseRef {
     type Error;
 
     /// Sets up a single account

--- a/src/protocol/vm/engine.rs
+++ b/src/protocol/vm/engine.rs
@@ -35,7 +35,7 @@ lazy_static! {
 /// - `mocked_tokens`: A list of addresses at which a mocked ERC20 contract should be inserted.
 /// - `trace`: Whether to trace calls. Only meant for debugging purposes, might print a lot of data
 ///   to stdout.
-pub fn create_engine<D: EngineDatabaseInterface + Clone + DatabaseRef>(
+pub fn create_engine<D: EngineDatabaseInterface + Clone>(
     db: D,
     tokens: Vec<String>,
     trace: bool,

--- a/src/protocol/vm/state.rs
+++ b/src/protocol/vm/state.rs
@@ -18,7 +18,6 @@ use revm::{
         alloy_primitives::Keccak256, keccak256, AccountInfo, Bytecode, B256, KECCAK_EMPTY,
         U256 as rU256,
     },
-    DatabaseRef,
 };
 use tracing::{info, warn};
 
@@ -52,7 +51,7 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-pub struct VMPoolState<D: DatabaseRef + EngineDatabaseInterface + Clone> {
+pub struct VMPoolState<D: EngineDatabaseInterface + Clone> {
     /// The pool's identifier
     pub id: String,
     /// The pool's token's addresses


### PR DESCRIPTION
Small simplification. Like this, EngineDatabaseInterface can only be implemented on those which implement the DatabaseRef trait, which makes sense for our case.