### PR TITLE
feat: add a builder for `VMPoolState`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7475,6 +7475,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7879,6 +7892,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-test",
  "tracing",
  "tracing-subscriber",
  "tycho-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ unicode-width = "0.1.13"
 once_cell = "1.20.2"
 
 [dev-dependencies]
+tokio-test = "0.4.4"
 mockito = "1.1.1"
 warp = "0.3.5"
 approx = "0.5.1"

--- a/src/protocol/vm/mod.rs
+++ b/src/protocol/vm/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod erc20_overwrite_factory;
 pub mod errors;
 mod models;
 pub mod state;
+pub mod state_builder;
 pub mod tycho_decoder;
 pub(crate) mod tycho_simulation_contract;
 pub mod utils;

--- a/src/protocol/vm/state.rs
+++ b/src/protocol/vm/state.rs
@@ -4,32 +4,18 @@ use std::{
 };
 
 use alloy_primitives::Address;
-use chrono::Utc;
-use ethers::{
-    abi::{decode, ParamType},
-    prelude::U256,
-    types::H160,
-    utils::to_checksum,
-};
+use ethers::{prelude::U256, types::H160};
 use itertools::Itertools;
-use revm::{
-    precompile::{Address as rAddress, Bytes},
-    primitives::{alloy_primitives::Keccak256, AccountInfo, Bytecode, KECCAK_EMPTY, U256 as rU256},
-    DatabaseRef,
-};
-use tracing::{info, warn};
+use revm::{precompile::Address as rAddress, primitives::U256 as rU256, DatabaseRef};
+use tracing::info;
 
 use tycho_core::dto::ProtocolStateDelta;
 
 use super::utils::{hexstring_to_vec, load_erc20_bytecode, ERC20Slots};
 use crate::{
     evm::{
-        engine_db_interface::EngineDatabaseInterface,
-        simulation::{SimulationEngine, SimulationParameters},
-        simulation_db::BlockHeader,
-        token,
-        tycho_db::PreCachedDB,
-        ContractCompiler,
+        engine_db_interface::EngineDatabaseInterface, simulation_db::BlockHeader,
+        tycho_db::PreCachedDB, ContractCompiler,
     },
     models::ERC20Token,
     protocol::{
@@ -39,11 +25,10 @@ use crate::{
         state::{ProtocolEvent, ProtocolSim},
         vm::{
             constants::{ADAPTER_ADDRESS, EXTERNAL_ACCOUNT, MAX_BALANCE},
-            engine::{create_engine, SHARED_TYCHO_DB},
             erc20_overwrite_factory::{ERC20OverwriteFactory, Overwrites},
             models::Capability,
             tycho_simulation_contract::TychoSimulationContract,
-            utils::{get_code_for_contract, SlotId},
+            utils::SlotId,
         },
     },
 };
@@ -81,223 +66,15 @@ where
     /// Each entry also specify the compiler with which the target contract was compiled. This is
     /// later used to compute storage slot for maps.
     pub token_storage_slots: HashMap<H160, (ERC20Slots, ContractCompiler)>,
-    /// The address to bytecode map of all stateless contracts used by the protocol
-    /// for simulations. If the bytecode is None, an RPC call is done to get the code from our node
-    pub stateless_contracts: HashMap<String, Option<Vec<u8>>>,
-    /// If set, vm will emit detailed traces about the execution
-    pub trace: bool,
     /// Indicates if the protocol uses custom update rules and requires update
     /// triggers to recalculate spot prices ect. Default is to update on all changes on
     /// the pool.
     pub manual_updates: bool,
-    engine: Option<SimulationEngine<D>>,
     /// The adapter contract. This is used to run simulations
-    adapter_contract: Option<TychoSimulationContract<D>>,
+    pub adapter_contract: TychoSimulationContract<D>,
 }
 
 impl VMPoolState<PreCachedDB> {
-    #[allow(clippy::too_many_arguments)]
-    pub async fn new(
-        id: String,
-        tokens: Vec<H160>,
-        block: BlockHeader,
-        balances: HashMap<H160, U256>,
-        balance_owner: Option<H160>,
-        adapter_contract_path: String,
-        involved_contracts: HashSet<H160>,
-        stateless_contracts: HashMap<String, Option<Vec<u8>>>,
-        manual_updates: bool,
-        trace: bool,
-    ) -> Result<Self, SimulationError> {
-        let mut state = VMPoolState {
-            id,
-            tokens,
-            block,
-            balances,
-            balance_owner,
-            spot_prices: HashMap::new(),
-            capabilities: HashSet::new(),
-            block_lasting_overwrites: HashMap::new(),
-            involved_contracts,
-            token_storage_slots: HashMap::new(),
-            stateless_contracts,
-            trace,
-            engine: None,
-            adapter_contract: None,
-            manual_updates,
-        };
-        state.set_engine().await?;
-        state.adapter_contract = Some(TychoSimulationContract::new_swap_adapter(
-            *ADAPTER_ADDRESS,
-            adapter_contract_path,
-            state
-                .engine
-                .clone()
-                .ok_or_else(|| SimulationError::NotInitialized("Simulation engine".to_string()))?,
-        )?);
-        state.set_capabilities()?;
-        state.init_token_storage_slots()?;
-        Ok(state)
-    }
-
-    async fn set_engine(&mut self) -> Result<(), SimulationError> {
-        if self.engine.is_none() {
-            let engine: SimulationEngine<_> = create_engine(SHARED_TYCHO_DB.clone(), self.trace)?;
-
-            // Mock the ERC20 contract at the given token addresses.
-            let mocked_contract_bytecode = load_erc20_bytecode()?;
-            for token_address in &self.tokens {
-                let info = AccountInfo {
-                    balance: Default::default(),
-                    nonce: 0,
-                    code_hash: KECCAK_EMPTY,
-                    code: Some(mocked_contract_bytecode.clone()),
-                };
-                engine.state.init_account(
-                    Address::parse_checksummed(to_checksum(token_address, None), None).map_err(
-                        |_| {
-                            SimulationError::EncodingError(
-                                "Checksum for token address must be valid".into(),
-                            )
-                        },
-                    )?,
-                    info,
-                    None,
-                    false,
-                );
-            }
-
-            engine.state.init_account(
-                *EXTERNAL_ACCOUNT,
-                AccountInfo {
-                    balance: *MAX_BALANCE,
-                    nonce: 0,
-                    code_hash: KECCAK_EMPTY,
-                    code: None,
-                },
-                None,
-                false,
-            );
-
-            for (address, bytecode) in self.stateless_contracts.iter() {
-                let (code, code_hash) = if bytecode.is_none() {
-                    let mut addr_str = format!("{:?}", address);
-                    if addr_str.starts_with("call") {
-                        addr_str = self
-                            .get_address_from_call(&engine, &addr_str)?
-                            .to_string();
-                    }
-                    let code = get_code_for_contract(&addr_str, None).await?;
-                    (Some(code.clone()), code.hash_slow())
-                } else {
-                    let code =
-                        Bytecode::new_raw(Bytes::from(bytecode.clone().ok_or_else(|| {
-                            SimulationError::DecodingError(
-                                "Byte code from stateless contracts is None".into(),
-                            )
-                        })?));
-                    (Some(code.clone()), code.hash_slow())
-                };
-                engine.state.init_account(
-                    rAddress::parse_checksummed(
-                        to_checksum(
-                            &address.parse().map_err(|_| {
-                                SimulationError::DecodingError(
-                                    "Couldn't parse address into string".into(),
-                                )
-                            })?,
-                            None,
-                        ),
-                        None,
-                    )
-                    .expect("Invalid checksum for external account address"),
-                    AccountInfo { balance: Default::default(), nonce: 0, code_hash, code },
-                    None,
-                    false,
-                );
-            }
-            self.engine = Some(engine);
-            Ok(())
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Gets the address of the code - mostly used for dynamic proxy implementations. For example,
-    /// some protocols have some dynamic math implementation that is given by the factory. When
-    /// we swap on the pools for such protocols, it will call the factory to get the implementation
-    /// and use it for the swap.
-    /// This method simulates the call to the pool, which gives us the address of the
-    /// implementation.
-    ///
-    /// # See Also
-    /// [Dynamic Address Resolution Example](https://github.com/propeller-heads/propeller-protocol-lib/blob/main/docs/indexing/reserved-attributes.md#description-2)
-    fn get_address_from_call(
-        &self,
-        engine: &SimulationEngine<PreCachedDB>,
-        decoded: &str,
-    ) -> Result<rAddress, SimulationError> {
-        let method_name = decoded
-            .split(':')
-            .last()
-            .ok_or_else(|| {
-                SimulationError::DecodingError("Invalid decoded string format".into())
-            })?;
-
-        let selector = {
-            let mut hasher = Keccak256::new();
-            hasher.update(method_name.as_bytes());
-            let result = hasher.finalize();
-            result[..4].to_vec()
-        };
-
-        let to_address = decoded
-            .split(':')
-            .nth(1)
-            .ok_or_else(|| {
-                SimulationError::DecodingError("Invalid decoded string format".into())
-            })?;
-
-        let timestamp = Utc::now()
-            .naive_utc()
-            .and_utc()
-            .timestamp() as u64;
-
-        let parsed_address: rAddress = to_address
-            .parse()
-            .map_err(|_| SimulationError::DecodingError("Invalid address format".into()))?;
-
-        let sim_params = SimulationParameters {
-            data: selector.to_vec().into(),
-            to: parsed_address,
-            block_number: self.block.number,
-            timestamp,
-            overrides: Some(HashMap::new()),
-            caller: *EXTERNAL_ACCOUNT,
-            value: 0.into(),
-            gas_limit: None,
-        };
-
-        let sim_result = engine
-            .simulate(&sim_params)
-            .map_err(SimulationError::SimulationEngineError)?;
-
-        let address = decode(&[ParamType::Address], &sim_result.result)
-            .map_err(|_| SimulationError::DecodingError("Failed to decode ABI".into()))?
-            .into_iter()
-            .next()
-            .ok_or_else(|| {
-                SimulationError::DecodingError(
-                    "Couldn't retrieve address from simulation for stateless contracts".into(),
-                )
-            })?;
-
-        address
-            .to_string()
-            .parse()
-            .map_err(|_| SimulationError::DecodingError("Couldn't parse address to string".into()))
-    }
-
     /// Ensures the pool supports the given capability
     fn ensure_capability(&self, capability: Capability) -> Result<(), SimulationError> {
         if !self.capabilities.contains(&capability) {
@@ -305,47 +82,6 @@ impl VMPoolState<PreCachedDB> {
                 "capability {:?}",
                 capability.to_string()
             )));
-        }
-        Ok(())
-    }
-
-    fn set_capabilities(&mut self) -> Result<(), SimulationError> {
-        let mut capabilities = Vec::new();
-        let pool_id_vec = hexstring_to_vec(&self.id.clone())?;
-
-        // Generate all permutations of tokens and retrieve capabilities
-        for tokens_pair in self.tokens.iter().permutations(2) {
-            // Manually unpack the inner vector
-            if let [t0, t1] = tokens_pair[..] {
-                let caps = self
-                    .adapter_contract
-                    .clone()
-                    .ok_or_else(|| SimulationError::NotInitialized("Adapter contract".to_string()))?
-                    .get_capabilities(pool_id_vec.clone(), *t0, *t1)?;
-                capabilities.push(caps);
-            }
-        }
-
-        // Find the maximum capabilities length
-        let max_capabilities = capabilities
-            .iter()
-            .map(|c| c.len())
-            .max()
-            .unwrap_or(0);
-
-        // Intersect all capability sets
-        let common_capabilities: HashSet<_> = capabilities
-            .iter()
-            .fold(capabilities[0].clone(), |acc, cap| acc.intersection(cap).cloned().collect());
-
-        self.capabilities = common_capabilities;
-
-        // Check for mismatches in capabilities
-        if self.capabilities.len() < max_capabilities {
-            warn!(
-                "Warning: Pool {} has different capabilities depending on the token pair!",
-                self.id
-            );
         }
         Ok(())
     }
@@ -368,18 +104,14 @@ impl VMPoolState<PreCachedDB> {
             )?;
             info!("Got sell amount limit for spot prices {:?}", &sell_amount_limit);
             let pool_id_vec = hexstring_to_vec(&self.id.clone())?;
-            let price_result = self
-                .adapter_contract
-                .clone()
-                .ok_or_else(|| SimulationError::NotInitialized("Adapter contract".to_string()))?
-                .price(
-                    pool_id_vec,
-                    sell_token.address,
-                    buy_token.address,
-                    vec![sell_amount_limit / U256::from(100)],
-                    self.block.number,
-                    overwrites,
-                )?;
+            let price_result = self.adapter_contract.price(
+                pool_id_vec,
+                sell_token.address,
+                buy_token.address,
+                vec![sell_amount_limit / U256::from(100)],
+                self.block.number,
+                overwrites,
+            )?;
 
             let price = if self
                 .capabilities
@@ -410,21 +142,21 @@ impl VMPoolState<PreCachedDB> {
         tokens: Vec<H160>,
         overwrites: Option<HashMap<Address, HashMap<U256, U256>>>,
     ) -> Result<U256, SimulationError> {
-        let binding = self
-            .adapter_contract
-            .clone()
-            .ok_or_else(|| SimulationError::NotInitialized("Adapter contract".to_string()))?;
         let pool_id_vec = hexstring_to_vec(&self.id.clone())?;
-        let limits =
-            binding.get_limits(pool_id_vec, tokens[0], tokens[1], self.block.number, overwrites);
+        let limits = self.adapter_contract.get_limits(
+            pool_id_vec,
+            tokens[0],
+            tokens[1],
+            self.block.number,
+            overwrites,
+        );
 
         Ok(limits?.0)
     }
 
     fn clear_all_cache(&mut self, tokens: Vec<ERC20Token>) -> Result<(), SimulationError> {
-        self.engine
-            .as_mut()
-            .ok_or_else(|| SimulationError::NotInitialized("Simulation engine".to_string()))?
+        self.adapter_contract
+            .engine
             .clear_temp_storage();
         self.block_lasting_overwrites.clear();
         self.set_spot_prices(tokens)?;
@@ -546,24 +278,6 @@ impl VMPoolState<PreCachedDB> {
 
         merged
     }
-
-    fn init_token_storage_slots(&mut self) -> Result<(), SimulationError> {
-        for t in self.tokens.iter() {
-            if self.involved_contracts.contains(t) && !self.token_storage_slots.contains_key(t) {
-                self.token_storage_slots.insert(
-                    *t,
-                    token::brute_force_slots(
-                        t,
-                        &self.block,
-                        self.engine
-                            .as_ref()
-                            .expect("engine should be set"),
-                    )?,
-                );
-            }
-        }
-        Ok(())
-    }
 }
 
 impl ProtocolSim for VMPoolState<PreCachedDB> {
@@ -609,19 +323,15 @@ impl ProtocolSim for VMPoolState<PreCachedDB> {
         let pool_id = self.id.clone();
         let pool_id_vec = hexstring_to_vec(&pool_id).unwrap();
 
-        let (trade, state_changes) = self
-            .adapter_contract
-            .as_ref()
-            .ok_or_else(|| SimulationError::NotInitialized("Adapter contract".to_string()))?
-            .swap(
-                pool_id_vec,
-                sell_token,
-                buy_token,
-                false,
-                sell_amount_respecting_limit,
-                self.block.number,
-                Some(complete_overwrites),
-            )?;
+        let (trade, state_changes) = self.adapter_contract.swap(
+            pool_id_vec,
+            sell_token,
+            buy_token,
+            false,
+            sell_amount_respecting_limit,
+            self.block.number,
+            Some(complete_overwrites),
+        )?;
 
         let mut new_state = self.clone();
 
@@ -732,7 +442,9 @@ mod tests {
     use ethers::{
         prelude::{H256, U256},
         types::Address as EthAddress,
+        utils::to_checksum,
     };
+    use revm::primitives::{AccountInfo, Bytecode, KECCAK_EMPTY};
     use serde_json::Value;
     use std::{
         collections::{HashMap, HashSet},
@@ -742,8 +454,14 @@ mod tests {
     };
 
     use crate::{
-        evm::{simulation_db::BlockHeader, tycho_models::AccountUpdate},
-        protocol::vm::models::Capability,
+        evm::{
+            simulation::SimulationEngine, simulation_db::BlockHeader, tycho_models::AccountUpdate,
+        },
+        protocol::vm::{
+            engine::{create_engine, SHARED_TYCHO_DB},
+            models::Capability,
+            state_builder::VMPoolStateBuilder,
+        },
     };
 
     fn dai() -> ERC20Token {
@@ -815,30 +533,29 @@ mod tests {
             "0x4626d81b3a1711beb79f4cecff2413886d461677000200000000000000000011".into();
         dbg!(&tokens);
 
-        let mut stateless_contracts = HashMap::new();
-        stateless_contracts
-            .insert(String::from("0x3de27efa2f1aa663ae5d458857e731c129069f29"), Some(vec![]));
+        let stateless_contracts = HashMap::from([(
+            String::from("0x3de27efa2f1aa663ae5d458857e731c129069f29"),
+            Some(Vec::new()),
+        )]);
 
-        VMPoolState::<PreCachedDB>::new(
-            pool_id,
-            tokens,
-            block,
-            HashMap::from([
+        VMPoolStateBuilder::new(pool_id, tokens, block)
+            .balances(HashMap::from([
                 (
                     EthAddress::from(dai_addr.0),
                     U256::from_dec_str("178754012737301807104").unwrap(),
                 ),
                 (EthAddress::from(bal_addr.0), U256::from_dec_str("91082987763369885696").unwrap()),
-            ]),
-            Some(EthAddress::from_str("0xBA12222222228d8Ba445958a75a0704d566BF2C8").unwrap()),
-            "src/protocol/vm/assets/BalancerSwapAdapter.evm.runtime".to_string(),
-            HashSet::new(),
-            stateless_contracts,
-            false,
-            false,
-        )
-        .await
-        .expect("Failed to initialize pool state")
+            ]))
+            .balance_owner(
+                EthAddress::from_str("0xBA12222222228d8Ba445958a75a0704d566BF2C8").unwrap(),
+            )
+            .adapter_contract_path(
+                "src/protocol/vm/assets/BalancerSwapAdapter.evm.runtime".to_string(),
+            )
+            .stateless_contracts(stateless_contracts)
+            .build()
+            .await
+            .expect("Failed to build pool state")
     }
 
     #[tokio::test]
@@ -861,9 +578,7 @@ mod tests {
         let pool_id_vec = hexstring_to_vec(&pool_state.id).unwrap();
 
         let capabilities_adapter_contract = pool_state
-            .clone()
             .adapter_contract
-            .unwrap()
             .get_capabilities(pool_id_vec, pool_state.tokens[0], pool_state.tokens[1])
             .unwrap();
 
@@ -887,8 +602,8 @@ mod tests {
 
         // Verify all tokens are initialized in the engine
         let engine_accounts = pool_state
+            .adapter_contract
             .engine
-            .unwrap()
             .state
             .clone()
             .get_account_storage();

--- a/src/protocol/vm/state.rs
+++ b/src/protocol/vm/state.rs
@@ -471,17 +471,9 @@ mod tests {
         ERC20Token::new("0xba100000625a3754423978a60c9317c58a424e3d", 18, "BAL", U256::from(10_000))
     }
 
-    static BALANCER_20463609_FIXTURE: OnceLock<Value> = OnceLock::new();
-
-    fn get_balancer_fixture() -> &'static Value {
-        BALANCER_20463609_FIXTURE.get_or_init(|| {
-            let data = include_str!("assets/balancer_contract_storage_block_20463609.json");
-            serde_json::from_str(data).expect("Failed to parse JSON")
-        })
-    }
-
     async fn setup_pool_state() -> VMPoolState<PreCachedDB> {
-        let data = get_balancer_fixture();
+        let data_str = include_str!("assets/balancer_contract_storage_block_20463609.json");
+        let data: Value = serde_json::from_str(data_str).expect("Failed to parse JSON");
 
         let accounts: Vec<AccountUpdate> = serde_json::from_value(data["accounts"].clone())
             .expect("Expected accounts to match AccountUpdate structure");

--- a/src/protocol/vm/state.rs
+++ b/src/protocol/vm/state.rs
@@ -71,10 +71,41 @@ where
     /// the pool.
     pub manual_updates: bool,
     /// The adapter contract. This is used to run simulations
-    pub adapter_contract: TychoSimulationContract<D>,
+    adapter_contract: TychoSimulationContract<D>,
 }
 
 impl VMPoolState<PreCachedDB> {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: String,
+        tokens: Vec<H160>,
+        block: BlockHeader,
+        balances: HashMap<H160, U256>,
+        balance_owner: Option<H160>,
+        spot_prices: HashMap<(H160, H160), f64>,
+        capabilities: HashSet<Capability>,
+        block_lasting_overwrites: HashMap<rAddress, Overwrites>,
+        involved_contracts: HashSet<H160>,
+        token_storage_slots: HashMap<H160, (ERC20Slots, ContractCompiler)>,
+        manual_updates: bool,
+        adapter_contract: TychoSimulationContract<PreCachedDB>,
+    ) -> Self {
+        Self {
+            id,
+            tokens,
+            block,
+            balances,
+            balance_owner,
+            spot_prices,
+            capabilities,
+            block_lasting_overwrites,
+            involved_contracts,
+            token_storage_slots,
+            manual_updates,
+            adapter_contract,
+        }
+    }
+
     /// Ensures the pool supports the given capability
     fn ensure_capability(&self, capability: Capability) -> Result<(), SimulationError> {
         if !self.capabilities.contains(&capability) {

--- a/src/protocol/vm/state.rs
+++ b/src/protocol/vm/state.rs
@@ -11,7 +11,7 @@ use tracing::info;
 
 use tycho_core::dto::ProtocolStateDelta;
 
-use super::utils::{hexstring_to_vec, load_erc20_bytecode, ERC20Slots};
+use super::utils::{hexstring_to_vec, ERC20Slots};
 use crate::{
     evm::{
         engine_db_interface::EngineDatabaseInterface, simulation_db::BlockHeader,
@@ -480,7 +480,6 @@ mod tests {
     use std::{
         collections::{HashMap, HashSet},
         str::FromStr,
-        sync::OnceLock,
     };
 
     use crate::{

--- a/src/protocol/vm/state_builder.rs
+++ b/src/protocol/vm/state_builder.rs
@@ -205,27 +205,23 @@ impl VMPoolStateBuilder {
         } else {
             self.get_default_capabilities()?
         };
-
-        Ok(VMPoolState {
-            id: self.id,
-            tokens: self.tokens,
-            block: self.block,
-            balances: self.balances.unwrap_or_default(),
-            balance_owner: self.balance_owner,
-            spot_prices: HashMap::new(),
+        Ok(VMPoolState::new(
+            self.id,
+            self.tokens,
+            self.block,
+            self.balances.unwrap_or_default(),
+            self.balance_owner,
+            HashMap::new(),
             capabilities,
-            block_lasting_overwrites: HashMap::new(),
-            involved_contracts: self
-                .involved_contracts
+            HashMap::new(),
+            self.involved_contracts
                 .unwrap_or_default(),
-            token_storage_slots: self
-                .token_storage_slots
+            self.token_storage_slots
                 .unwrap_or_default(),
-            manual_updates: self.manual_updates.unwrap_or(false),
-            adapter_contract: self
-                .adapter_contract
+            self.manual_updates.unwrap_or(false),
+            self.adapter_contract
                 .ok_or_else(|| SimulationError::NotInitialized("Adapter contract".to_string()))?,
-        })
+        ))
     }
 
     async fn get_default_engine(

--- a/src/protocol/vm/state_builder.rs
+++ b/src/protocol/vm/state_builder.rs
@@ -46,6 +46,38 @@ use crate::{
 /// `VMPoolState`. This struct provides a flexible way to construct `VMPoolState` objects with
 /// multiple optional parameters. It handles the validation of required fields and applies default
 /// values for optional parameters where necessary.
+/// # Example
+/// Constructing a `VMPoolState` with only the required parameters:
+/// ```rust
+/// use ethers::types::H160;
+/// use crate::evm::simulation_db::BlockHeader;
+/// use crate::protocol::errors::SimulationError;
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), SimulationError> {
+///     // Required parameters
+///     let pool_id = "0xabc123".to_string();
+///     let tokens = vec![H160::zero()];
+///     let block = BlockHeader {
+///         number: 1,
+///         hash: Default::default(),
+///         timestamp: 1632456789,
+///     };
+///     
+///     // Optional: Add token balances
+///     let mut balances = HashMap::new();
+///     balances.insert(H160::zero(), U256::from(1000));
+///
+///     // Build the VMPoolState
+///     let pool_state = VMPoolStateBuilder::new(pool_id, tokens, block)
+///         .balances(balances)
+///         .build()
+///         .await?;
+///
+///     println!("Successfully created VMPoolState: {:?}", pool_state);
+///     Ok(())
+/// }
+/// ```
 pub struct VMPoolStateBuilder {
     id: String,
     tokens: Vec<H160>,

--- a/src/protocol/vm/state_builder.rs
+++ b/src/protocol/vm/state_builder.rs
@@ -1,0 +1,461 @@
+use std::collections::{HashMap, HashSet};
+
+use alloy_primitives::Address;
+use chrono::Utc;
+use ethers::{
+    abi::{decode, ParamType},
+    prelude::U256,
+    types::H160,
+    utils::to_checksum,
+};
+use itertools::Itertools;
+use revm::{
+    precompile::{Address as rAddress, Bytes},
+    primitives::{alloy_primitives::Keccak256, AccountInfo, Bytecode, KECCAK_EMPTY},
+};
+use tracing::warn;
+
+use super::{
+    constants::ADAPTER_ADDRESS,
+    state::VMPoolState,
+    utils::{hexstring_to_vec, load_erc20_bytecode, ERC20Slots},
+};
+use crate::{
+    evm::{
+        engine_db_interface::EngineDatabaseInterface,
+        simulation::{SimulationEngine, SimulationParameters},
+        simulation_db::BlockHeader,
+        token,
+        tycho_db::PreCachedDB,
+        ContractCompiler,
+    },
+    protocol::{
+        errors::SimulationError,
+        vm::{
+            constants::{EXTERNAL_ACCOUNT, MAX_BALANCE},
+            engine::{create_engine, SHARED_TYCHO_DB},
+            models::Capability,
+            tycho_simulation_contract::TychoSimulationContract,
+            utils::get_code_for_contract,
+        },
+    },
+};
+
+#[derive(Debug)]
+/// `VMPoolStateBuilder` is a builder pattern implementation for creating instances of
+/// `VMPoolState`. This struct provides a flexible way to construct `VMPoolState` objects with
+/// multiple optional parameters. It handles the validation of required fields and applies default
+/// values for optional parameters where necessary.
+pub struct VMPoolStateBuilder {
+    id: String,
+    tokens: Vec<H160>,
+    block: BlockHeader,
+    balances: Option<HashMap<H160, U256>>,
+    balance_owner: Option<H160>,
+    capabilities: Option<HashSet<Capability>>,
+    involved_contracts: Option<HashSet<H160>>,
+    stateless_contracts: Option<HashMap<String, Option<Vec<u8>>>>,
+    token_storage_slots: Option<HashMap<H160, (ERC20Slots, ContractCompiler)>>,
+    manual_updates: Option<bool>,
+    trace: Option<bool>,
+    engine: Option<SimulationEngine<PreCachedDB>>,
+    adapter_contract: Option<TychoSimulationContract<PreCachedDB>>,
+    adapter_contract_path: Option<String>,
+}
+
+impl VMPoolStateBuilder {
+    pub fn new(id: String, tokens: Vec<H160>, block: BlockHeader) -> Self {
+        Self {
+            id,
+            tokens,
+            block,
+            balances: None,
+            balance_owner: None,
+            capabilities: None,
+            involved_contracts: None,
+            stateless_contracts: None,
+            token_storage_slots: None,
+            manual_updates: None,
+            trace: None,
+            engine: None,
+            adapter_contract: None,
+            adapter_contract_path: None,
+        }
+    }
+
+    pub fn balances(mut self, balances: HashMap<H160, U256>) -> Self {
+        self.balances = Some(balances);
+        self
+    }
+
+    pub fn balance_owner(mut self, balance_owner: H160) -> Self {
+        self.balance_owner = Some(balance_owner);
+        self
+    }
+
+    pub fn capabilities(mut self, capabilities: HashSet<Capability>) -> Self {
+        self.capabilities = Some(capabilities);
+        self
+    }
+
+    pub fn involved_contracts(mut self, involved_contracts: HashSet<H160>) -> Self {
+        self.involved_contracts = Some(involved_contracts);
+        self
+    }
+
+    pub fn stateless_contracts(
+        mut self,
+        stateless_contracts: HashMap<String, Option<Vec<u8>>>,
+    ) -> Self {
+        self.stateless_contracts = Some(stateless_contracts);
+        self
+    }
+
+    pub fn token_storage_slots(
+        mut self,
+        token_storage_slots: HashMap<H160, (ERC20Slots, ContractCompiler)>,
+    ) -> Self {
+        self.token_storage_slots = Some(token_storage_slots);
+        self
+    }
+
+    pub fn manual_updates(mut self, manual_updates: bool) -> Self {
+        self.manual_updates = Some(manual_updates);
+        self
+    }
+
+    pub fn trace(mut self, trace: bool) -> Self {
+        self.trace = Some(trace);
+        self
+    }
+
+    pub fn engine(mut self, engine: SimulationEngine<PreCachedDB>) -> Self {
+        self.engine = Some(engine);
+        self
+    }
+
+    pub fn adapter_contract(
+        mut self,
+        adapter_contract: TychoSimulationContract<PreCachedDB>,
+    ) -> Self {
+        self.adapter_contract = Some(adapter_contract);
+        self
+    }
+
+    pub fn adapter_contract_path(mut self, adapter_contract_path: String) -> Self {
+        self.adapter_contract_path = Some(adapter_contract_path);
+        self
+    }
+
+    /// Build the final VMPoolState object
+    pub async fn build(mut self) -> Result<VMPoolState<PreCachedDB>, SimulationError> {
+        let engine = if let Some(engine) = &self.engine {
+            engine.clone()
+        } else {
+            self.get_default_engine().await?
+        };
+
+        if self.adapter_contract.is_none() {
+            self.adapter_contract = Some(TychoSimulationContract::new_swap_adapter(
+                *ADAPTER_ADDRESS,
+                self.adapter_contract_path
+                    .as_ref()
+                    .ok_or_else(|| {
+                        SimulationError::NotInitialized("Adapter contract".to_string())
+                    })?,
+                engine.clone(),
+            )?)
+        };
+
+        self.init_token_storage_slots()?;
+        let capabilities = if let Some(capabilities) = &self.capabilities {
+            capabilities.clone()
+        } else {
+            self.get_default_capabilities()?
+        };
+
+        Ok(VMPoolState {
+            id: self.id,
+            tokens: self.tokens,
+            block: self.block,
+            balances: self.balances.unwrap_or_default(),
+            balance_owner: self.balance_owner,
+            spot_prices: HashMap::new(),
+            capabilities,
+            block_lasting_overwrites: HashMap::new(),
+            involved_contracts: self
+                .involved_contracts
+                .unwrap_or_default(),
+            token_storage_slots: self
+                .token_storage_slots
+                .unwrap_or_default(),
+            manual_updates: self.manual_updates.unwrap_or(false),
+            adapter_contract: self
+                .adapter_contract
+                .ok_or_else(|| SimulationError::NotInitialized("Adapter contract".to_string()))?,
+        })
+    }
+
+    async fn get_default_engine(
+        &mut self,
+    ) -> Result<SimulationEngine<PreCachedDB>, SimulationError> {
+        let engine = create_engine(SHARED_TYCHO_DB.clone(), self.trace.unwrap_or(false))?;
+
+        // Mock the ERC20 contract at the given token addresses.
+        let mocked_contract_bytecode = load_erc20_bytecode()?;
+        for token_address in &self.tokens {
+            let info = AccountInfo {
+                balance: Default::default(),
+                nonce: 0,
+                code_hash: KECCAK_EMPTY,
+                code: Some(mocked_contract_bytecode.clone()),
+            };
+            engine.state.init_account(
+                Address::parse_checksummed(to_checksum(token_address, None), None).map_err(
+                    |_| {
+                        SimulationError::EncodingError(
+                            "Checksum for token address must be valid".into(),
+                        )
+                    },
+                )?,
+                info,
+                None,
+                false,
+            );
+        }
+
+        engine.state.init_account(
+            *EXTERNAL_ACCOUNT,
+            AccountInfo { balance: *MAX_BALANCE, nonce: 0, code_hash: KECCAK_EMPTY, code: None },
+            None,
+            false,
+        );
+
+        if let Some(stateless_contracts) = &self.stateless_contracts {
+            for (address, bytecode) in stateless_contracts.iter() {
+                let (code, code_hash) = if bytecode.is_none() {
+                    let mut addr_str = format!("{:?}", address);
+                    if addr_str.starts_with("call") {
+                        addr_str = self
+                            .get_address_from_call(&engine, &addr_str)?
+                            .to_string();
+                    }
+                    let code = get_code_for_contract(&addr_str, None).await?;
+                    (Some(code.clone()), code.hash_slow())
+                } else {
+                    let code =
+                        Bytecode::new_raw(Bytes::from(bytecode.clone().ok_or_else(|| {
+                            SimulationError::DecodingError(
+                                "Byte code from stateless contracts is None".into(),
+                            )
+                        })?));
+                    (Some(code.clone()), code.hash_slow())
+                };
+                engine.state.init_account(
+                    rAddress::parse_checksummed(
+                        to_checksum(
+                            &address.parse().map_err(|_| {
+                                SimulationError::DecodingError(
+                                    "Couldn't parse address into string".into(),
+                                )
+                            })?,
+                            None,
+                        ),
+                        None,
+                    )
+                    .expect("Invalid checksum for external account address"),
+                    AccountInfo { balance: Default::default(), nonce: 0, code_hash, code },
+                    None,
+                    false,
+                );
+            }
+        }
+        Ok(engine)
+    }
+
+    fn init_token_storage_slots(&mut self) -> Result<(), SimulationError> {
+        for t in self.tokens.iter() {
+            if self
+                .involved_contracts
+                .as_ref()
+                .is_some_and(|contracts| contracts.contains(t)) &&
+                !self
+                    .token_storage_slots
+                    .as_ref()
+                    .is_some_and(|token_storage| token_storage.contains_key(t))
+            {
+                self.token_storage_slots
+                    .get_or_insert(HashMap::new())
+                    .insert(
+                        *t,
+                        token::brute_force_slots(
+                            t,
+                            &self.block,
+                            self.engine
+                                .as_ref()
+                                .expect("engine should be set"),
+                        )?,
+                    );
+            }
+        }
+        Ok(())
+    }
+
+    fn get_default_capabilities(&mut self) -> Result<HashSet<Capability>, SimulationError> {
+        let mut capabilities = Vec::new();
+
+        // Generate all permutations of tokens and retrieve capabilities
+        for tokens_pair in self.tokens.iter().permutations(2) {
+            // Manually unpack the inner vector
+            if let [t0, t1] = tokens_pair[..] {
+                let caps = self
+                    .adapter_contract
+                    .clone()
+                    .ok_or_else(|| SimulationError::NotInitialized("Adapter contract".to_string()))?
+                    .get_capabilities(hexstring_to_vec(&self.id)?, *t0, *t1)?;
+                capabilities.push(caps);
+            }
+        }
+
+        // Find the maximum capabilities length
+        let max_capabilities = capabilities
+            .iter()
+            .map(|c| c.len())
+            .max()
+            .unwrap_or(0);
+
+        // Intersect all capability sets
+        let common_capabilities: HashSet<_> = capabilities
+            .iter()
+            .fold(capabilities[0].clone(), |acc, cap| acc.intersection(cap).cloned().collect());
+
+        // Check for mismatches in capabilities
+        if common_capabilities.len() < max_capabilities {
+            warn!(
+                "Warning: Pool {} has different capabilities depending on the token pair!",
+                self.id
+            );
+        }
+        Ok(common_capabilities)
+    }
+
+    /// Gets the address of the code - mostly used for dynamic proxy implementations. For example,
+    /// some protocols have some dynamic math implementation that is given by the factory. When
+    /// we swap on the pools for such protocols, it will call the factory to get the implementation
+    /// and use it for the swap.
+    /// This method simulates the call to the pool, which gives us the address of the
+    /// implementation.
+    ///
+    /// # See Also
+    /// [Dynamic Address Resolution Example](https://github.com/propeller-heads/propeller-protocol-lib/blob/main/docs/indexing/reserved-attributes.md#description-2)
+    fn get_address_from_call(
+        &self,
+        engine: &SimulationEngine<PreCachedDB>,
+        decoded: &str,
+    ) -> Result<rAddress, SimulationError> {
+        let method_name = decoded
+            .split(':')
+            .last()
+            .ok_or_else(|| {
+                SimulationError::DecodingError("Invalid decoded string format".into())
+            })?;
+
+        let selector = {
+            let mut hasher = Keccak256::new();
+            hasher.update(method_name.as_bytes());
+            let result = hasher.finalize();
+            result[..4].to_vec()
+        };
+
+        let to_address = decoded
+            .split(':')
+            .nth(1)
+            .ok_or_else(|| {
+                SimulationError::DecodingError("Invalid decoded string format".into())
+            })?;
+
+        let timestamp = Utc::now()
+            .naive_utc()
+            .and_utc()
+            .timestamp() as u64;
+
+        let parsed_address: rAddress = to_address
+            .parse()
+            .map_err(|_| SimulationError::DecodingError("Invalid address format".into()))?;
+
+        let sim_params = SimulationParameters {
+            data: selector.to_vec().into(),
+            to: parsed_address,
+            block_number: self.block.number,
+            timestamp,
+            overrides: Some(HashMap::new()),
+            caller: *EXTERNAL_ACCOUNT,
+            value: 0.into(),
+            gas_limit: None,
+        };
+
+        let sim_result = engine
+            .simulate(&sim_params)
+            .map_err(SimulationError::SimulationEngineError)?;
+
+        let address = decode(&[ParamType::Address], &sim_result.result)
+            .map_err(|_| SimulationError::DecodingError("Failed to decode ABI".into()))?
+            .into_iter()
+            .next()
+            .ok_or_else(|| {
+                SimulationError::DecodingError(
+                    "Couldn't retrieve address from simulation for stateless contracts".into(),
+                )
+            })?;
+
+        address
+            .to_string()
+            .parse()
+            .map_err(|_| SimulationError::DecodingError("Couldn't parse address to string".into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+    use ethers::types::{H160, H256};
+
+    #[test]
+    fn test_build_without_required_fields() {
+        let id = "pool_1".to_string();
+        let tokens = vec![H160::zero()];
+        let block = BlockHeader { number: 1, hash: H256::default(), timestamp: 234 };
+
+        let result = tokio_test::block_on(VMPoolStateBuilder::new(id, tokens, block).build());
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SimulationError::NotInitialized(field) => assert_eq!(field, "Adapter contract"),
+            _ => panic!("Unexpected error type"),
+        }
+    }
+
+    #[test]
+    fn test_engine_setup() {
+        let id = "pool_1".to_string();
+        let token2 = H160::from_str("0000000000000000000000000000000000000002").unwrap();
+        let token3 = H160::from_str("0000000000000000000000000000000000000003").unwrap();
+        let tokens = vec![token2, token3];
+        let block = BlockHeader { number: 1, hash: H256::default(), timestamp: 234 };
+
+        let mut builder = VMPoolStateBuilder::new(id, tokens, block);
+
+        let engine = tokio_test::block_on(builder.get_default_engine()).unwrap();
+
+        assert!(engine
+            .state
+            .get_account_storage()
+            .account_present(&Address::from_slice(token2.as_bytes())));
+        assert!(engine
+            .state
+            .get_account_storage()
+            .account_present(&Address::from_slice(token3.as_bytes())));
+    }
+}

--- a/src/protocol/vm/tycho_simulation_contract.rs
+++ b/src/protocol/vm/tycho_simulation_contract.rs
@@ -66,7 +66,8 @@ where
 {
     abi: Abi,
     address: Address,
-    engine: SimulationEngine<D>,
+    pub(crate) engine: SimulationEngine<D>, /* TODO: Should we expose it directly or make some
+                                             * getter functions? */
 }
 
 impl<D: EngineDatabaseInterface + Clone> TychoSimulationContract<D>
@@ -85,13 +86,13 @@ where
     // Creates a new instance with the ISwapAdapter ABI
     pub fn new_swap_adapter(
         address: Address,
-        adapter_contract_path: String,
+        adapter_contract_path: &str,
         engine: SimulationEngine<D>,
     ) -> Result<Self, SimulationError> {
         let abi = load_swap_abi()?;
 
         let adapter_contract_code =
-            get_contract_bytecode(&adapter_contract_path).map_err(SimulationError::AbiError)?;
+            get_contract_bytecode(adapter_contract_path).map_err(SimulationError::AbiError)?;
 
         engine.state.init_account(
             rAddress::parse_checksummed(ADAPTER_ADDRESS.to_string(), None)
@@ -108,6 +109,7 @@ where
 
         Ok(Self { address, abi, engine })
     }
+
     fn encode_input(&self, fname: &str, args: Vec<Token>) -> Result<Vec<u8>, SimulationError> {
         let function = self
             .abi
@@ -297,7 +299,7 @@ mod tests {
         let engine = create_mock_engine();
         TychoSimulationContract::new_swap_adapter(
             address,
-            "src/protocol/vm/assets/BalancerSwapAdapter.evm.runtime".to_string(),
+            "src/protocol/vm/assets/BalancerSwapAdapter.evm.runtime",
             engine,
         )
         .unwrap()


### PR DESCRIPTION
This PR aims to abstract away a lot of complexity that is in `VMPoolState` by using a builder pattern.

Currently, the `VMPoolState` is responsible for its own initialization. This one being quite complex, we had to tweak the `VMPoolState` struct itself. This adds a lot of unnecessary complexity and unexpected behavior.

The builder pattern helps us separating the initialisation and the execution of `VMPoolState`, making it more straightforward and simpler. For example many field were given to `VMPoolState` just for initialisation and never used after (`engine`, `trace`, ect..). Some were also `Option` but actually required at runtime (like `adapter_contract`).
    
The builder also allow any field to be directly given, this is useful for example if someone wants to manually create the `AdapterContract` instead of using the default.


This PR also improve speed for some tests that were very slow.

Before:

```
    Starting 6 tests across 3 binaries (170 tests skipped)
        PASS [  26.976s] tycho-simulation protocol::vm::state::tests::test_get_amount_out_dust
        PASS [  27.605s] tycho-simulation protocol::vm::state::tests::test_get_sell_amount_limit
        PASS [  27.646s] tycho-simulation protocol::vm::state::tests::test_init
        PASS [  27.731s] tycho-simulation protocol::vm::state::tests::test_set_spot_prices
        PASS [  27.835s] tycho-simulation protocol::vm::state::tests::test_get_amount_out
        PASS [  27.838s] tycho-simulation protocol::vm::state::tests::test_get_amount_out_sell_limit
```

After:

```
    Starting 6 tests across 3 binaries (170 tests skipped)
        PASS [   0.964s] tycho-simulation protocol::vm::state::tests::test_init
        PASS [   0.965s] tycho-simulation protocol::vm::state::tests::test_get_sell_amount_limit
        PASS [   0.970s] tycho-simulation protocol::vm::state::tests::test_get_amount_out
        PASS [   0.969s] tycho-simulation protocol::vm::state::tests::test_get_amount_out_dust
        PASS [   0.968s] tycho-simulation protocol::vm::state::tests::test_get_amount_out_sell_limit
        PASS [   0.967s] tycho-simulation protocol::vm::state::tests::test_set_spot_prices
```

