### PR TITLE
fix: Don't use unwrap_or_default if balance not found

### DIFF
--- a/src/evm/protocol/vm/state.rs
+++ b/src/evm/protocol/vm/state.rs
@@ -292,7 +292,15 @@ impl EVMPoolState<PreCachedDB> {
                 self.balances
                     .get(token)
                     .cloned()
-                    .unwrap_or_default(),
+                    .ok_or_else(|| {
+                        SimulationError::InvalidInput(
+                            format!(
+                                "Failed to get balance overwrites: Token balance not found for {}",
+                                token
+                            ),
+                            None,
+                        )
+                    })?,
                 address,
             );
             balance_overwrites.extend(overwrites.get_overwrites());

--- a/src/evm/protocol/vm/state.rs
+++ b/src/evm/protocol/vm/state.rs
@@ -583,14 +583,12 @@ mod tests {
             Some(Vec::new()),
         )]);
 
-        EVMPoolStateBuilder::new(pool_id, tokens, block)
-            .balances(HashMap::from([
-                (
-                    EthAddress::from(dai_addr.0),
-                    U256::from_dec_str("178754012737301807104").unwrap(),
-                ),
-                (EthAddress::from(bal_addr.0), U256::from_dec_str("91082987763369885696").unwrap()),
-            ]))
+        let balances = HashMap::from([
+            (EthAddress::from(dai_addr.0), U256::from_dec_str("178754012737301807104").unwrap()),
+            (EthAddress::from(bal_addr.0), U256::from_dec_str("91082987763369885696").unwrap()),
+        ]);
+
+        EVMPoolStateBuilder::new(pool_id, tokens, balances, block)
             .balance_owner(
                 EthAddress::from_str("0xBA12222222228d8Ba445958a75a0704d566BF2C8").unwrap(),
             )

--- a/src/evm/protocol/vm/state_builder.rs
+++ b/src/evm/protocol/vm/state_builder.rs
@@ -204,7 +204,12 @@ impl EVMPoolStateBuilder {
             self.id,
             self.tokens,
             self.block,
-            self.balances.unwrap_or_default(),
+            self.balances.ok_or_else(|| {
+                SimulationError::InvalidInput(
+                    "Failed to get build engine: Balances not initialized".to_string(),
+                    None,
+                )
+            })?,
             self.balance_owner,
             HashMap::new(),
             capabilities,

--- a/src/evm/protocol/vm/state_builder.rs
+++ b/src/evm/protocol/vm/state_builder.rs
@@ -64,8 +64,7 @@ use super::{
 ///     balances.insert(H160::zero(), U256::from(1000));
 ///
 ///     // Build the EVMPoolState
-///     let pool_state = EVMPoolStateBuilder::new(pool_id, tokens, block)
-///         .balances(balances)
+///     let pool_state = EVMPoolStateBuilder::new(pool_id, tokens, balances, block)
 ///         .build()
 ///         .await?;
 ///
@@ -77,7 +76,7 @@ pub struct EVMPoolStateBuilder {
     id: String,
     tokens: Vec<H160>,
     block: BlockHeader,
-    balances: Option<HashMap<H160, U256>>,
+    balances: HashMap<H160, U256>,
     balance_owner: Option<H160>,
     capabilities: Option<HashSet<Capability>>,
     involved_contracts: Option<HashSet<H160>>,
@@ -91,12 +90,17 @@ pub struct EVMPoolStateBuilder {
 }
 
 impl EVMPoolStateBuilder {
-    pub fn new(id: String, tokens: Vec<H160>, block: BlockHeader) -> Self {
+    pub fn new(
+        id: String,
+        tokens: Vec<H160>,
+        balances: HashMap<H160, U256>,
+        block: BlockHeader,
+    ) -> Self {
         Self {
             id,
             tokens,
+            balances,
             block,
-            balances: None,
             balance_owner: None,
             capabilities: None,
             involved_contracts: None,
@@ -108,11 +112,6 @@ impl EVMPoolStateBuilder {
             adapter_contract: None,
             adapter_contract_path: None,
         }
-    }
-
-    pub fn balances(mut self, balances: HashMap<H160, U256>) -> Self {
-        self.balances = Some(balances);
-        self
     }
 
     pub fn balance_owner(mut self, balance_owner: H160) -> Self {
@@ -204,12 +203,7 @@ impl EVMPoolStateBuilder {
             self.id,
             self.tokens,
             self.block,
-            self.balances.ok_or_else(|| {
-                SimulationError::InvalidInput(
-                    "Failed to get build engine: Balances not initialized".to_string(),
-                    None,
-                )
-            })?,
+            self.balances,
             self.balance_owner,
             HashMap::new(),
             capabilities,
@@ -466,9 +460,11 @@ mod tests {
     fn test_build_without_required_fields() {
         let id = "pool_1".to_string();
         let tokens = vec![H160::zero()];
+        let balances = HashMap::new();
         let block = BlockHeader { number: 1, hash: H256::default(), timestamp: 234 };
 
-        let result = tokio_test::block_on(EVMPoolStateBuilder::new(id, tokens, block).build());
+        let result =
+            tokio_test::block_on(EVMPoolStateBuilder::new(id, tokens, balances, block).build());
 
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -486,8 +482,9 @@ mod tests {
         let token3 = H160::from_str("0000000000000000000000000000000000000003").unwrap();
         let tokens = vec![token2, token3];
         let block = BlockHeader { number: 1, hash: H256::default(), timestamp: 234 };
+        let balances = HashMap::new();
 
-        let mut builder = EVMPoolStateBuilder::new(id, tokens, block);
+        let mut builder = EVMPoolStateBuilder::new(id, tokens, balances, block);
 
         let engine = tokio_test::block_on(builder.get_default_engine()).unwrap();
 

--- a/src/evm/protocol/vm/tycho_decoder.rs
+++ b/src/evm/protocol/vm/tycho_decoder.rs
@@ -124,12 +124,12 @@ impl TryFromWithBlock<ComponentWithState> for EVMPoolState<PreCachedDB> {
             format!("src/evm/protocol/vm/assets/{}", to_adapter_file_name(protocol_name));
         info!("Creating a new pool state for balancer pool with id {}", &id);
 
-        let mut pool_state_builder = EVMPoolStateBuilder::new(id.clone(), tokens.clone(), block)
-            .balances(balances)
-            .adapter_contract_path(adapter_file_path)
-            .involved_contracts(involved_contracts)
-            .stateless_contracts(stateless_contracts)
-            .manual_updates(manual_updates);
+        let mut pool_state_builder =
+            EVMPoolStateBuilder::new(id.clone(), tokens.clone(), balances, block)
+                .adapter_contract_path(adapter_file_path)
+                .involved_contracts(involved_contracts)
+                .stateless_contracts(stateless_contracts)
+                .manual_updates(manual_updates);
 
         if let Some(balance_owner) = balance_owner {
             pool_state_builder = pool_state_builder.balance_owner(balance_owner)


### PR DESCRIPTION
This is bug prone. If the user forgets to initialize the balance, we should raise an error instead.