### PR TITLE
fix: Don't copy block_lasting_overwrites in get_overwrites

### DIFF
--- a/tycho_simulation_py/python/tycho_simulation_py/evm/pool_state.py
+++ b/tycho_simulation_py/python/tycho_simulation_py/evm/pool_state.py
@@ -280,7 +280,7 @@ class ThirdPartyPool:
         level, and token-specific overwrites that depend on passed tokens.
         """
         token_overwrites = self._get_token_overwrites(sell_token, buy_token, **kwargs)
-        return _merge(self.block_lasting_overwrites.copy(), token_overwrites)
+        return _merge(self.block_lasting_overwrites, token_overwrites)
 
     def _get_token_overwrites(
         self, sell_token: EthereumToken, buy_token: EthereumToken, max_amount=None


### PR DESCRIPTION
This was breaking the defibot tests

The whole block_lasting_overwrites logic relies on being able to change the object in place 🫠 