### PR TITLE
feat: Change ERC20Token address to be alloy's Address instead of H160

### DIFF
--- a/examples/explorer/data_feed/tycho.rs
+++ b/examples/explorer/data_feed/tycho.rs
@@ -17,7 +17,6 @@ use tycho_client::{
     HttpRPCClient,
 };
 use tycho_core::{dto::Chain, Bytes};
-use tycho_ethereum::BytesCodec;
 use tycho_simulation::{
     evm::{
         engine_db::{
@@ -164,7 +163,7 @@ pub async fn process_messages(
                     .for_each(|(addr, token)| {
                         if token.quality >= 51 {
                             all_tokens
-                                .entry(addr.clone())
+                                .entry(Address::from_slice(addr))
                                 .or_insert_with(|| {
                                     token
                                         .clone()
@@ -185,7 +184,11 @@ pub async fn process_messages(
                         let tokens = comp
                             .tokens
                             .iter()
-                            .flat_map(|addr| all_tokens.get(addr).cloned())
+                            .flat_map(|addr| {
+                                all_tokens
+                                    .get(&Address::from_slice(addr))
+                                    .cloned()
+                            })
                             .collect::<Vec<_>>();
                         let id = Bytes::from_str(id).unwrap_or_else(|_| {
                             panic!("Failed parsing H160 from id string {}", id)
@@ -226,7 +229,7 @@ pub async fn process_messages(
                 let mut skip_pool = false;
 
                 for token in snapshot.component.tokens.clone() {
-                    match all_tokens.get(&token) {
+                    match all_tokens.get(&Address::from_slice(&token)) {
                         Some(token) => pair_tokens.push(token.clone()),
                         None => {
                             debug!(
@@ -337,9 +340,7 @@ pub async fn process_messages(
                                 let tokens: Vec<ERC20Token> = vm_state
                                     .tokens
                                     .iter()
-                                    .filter_map(|token_address| {
-                                        all_tokens.get(&token_address.to_bytes())
-                                    })
+                                    .filter_map(|token_address| all_tokens.get(token_address))
                                     .cloned()
                                     .collect();
 
@@ -361,7 +362,7 @@ pub async fn process_messages(
                                         .downcast_mut::<EVMPoolState<PreCachedDB>>() {
                                         let tokens: Vec<ERC20Token> = vm_state.tokens
                                             .iter()
-                                            .filter_map(|token_address| all_tokens.get(&token_address.to_bytes()))
+                                            .filter_map(|token_address| all_tokens.get(token_address))
                                             .cloned()
                                             .collect();
 
@@ -430,7 +431,7 @@ pub async fn process_messages(
 pub async fn load_all_tokens(
     tycho_url: &str,
     auth_key: Option<&str>,
-) -> HashMap<Bytes, ERC20Token> {
+) -> HashMap<Address, ERC20Token> {
     let rpc_url = format!("https://{tycho_url}");
     let rpc_client = HttpRPCClient::new(rpc_url.as_str(), auth_key).unwrap();
 
@@ -443,7 +444,7 @@ pub async fn load_all_tokens(
         .map(|token| {
             let token_clone = token.clone();
             (
-                token.address.clone(),
+                Address::from_slice(&token.address),
                 token.try_into().unwrap_or_else(|_| {
                     panic!("Couldn't convert {:?} into ERC20 token.", token_clone)
                 }),

--- a/src/evm/protocol/uniswap_v2/state.rs
+++ b/src/evm/protocol/uniswap_v2/state.rs
@@ -286,7 +286,7 @@ mod tests {
             10_000.to_biguint().unwrap(),
         );
         let weth = ERC20Token::new(
-            "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 ",
+            "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
             18,
             "WETH",
             10_000.to_biguint().unwrap(),

--- a/src/evm/protocol/uniswap_v2/tycho_decoder.rs
+++ b/src/evm/protocol/uniswap_v2/tycho_decoder.rs
@@ -1,7 +1,6 @@
-use alloy_primitives::U256;
+use alloy_primitives::{Address, U256};
 use std::collections::HashMap;
 use tycho_client::feed::{synchronizer::ComponentWithState, Header};
-use tycho_core::Bytes;
 
 use crate::{
     models::ERC20Token,
@@ -18,7 +17,7 @@ impl TryFromWithBlock<ComponentWithState> for UniswapV2State {
     async fn try_from_with_block(
         snapshot: ComponentWithState,
         _block: Header,
-        _all_tokens: HashMap<Bytes, ERC20Token>,
+        _all_tokens: HashMap<Address, ERC20Token>,
     ) -> Result<Self, Self::Error> {
         let reserve0 = U256::from_be_slice(
             snapshot

--- a/src/evm/protocol/uniswap_v3/tycho_decoder.rs
+++ b/src/evm/protocol/uniswap_v3/tycho_decoder.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::U256;
+use alloy_primitives::{Address, U256};
 use std::collections::HashMap;
 
 use tycho_client::feed::{synchronizer::ComponentWithState, Header};
@@ -19,7 +19,7 @@ impl TryFromWithBlock<ComponentWithState> for UniswapV3State {
     async fn try_from_with_block(
         snapshot: ComponentWithState,
         _block: Header,
-        _all_tokens: HashMap<Bytes, ERC20Token>,
+        _all_tokens: HashMap<Address, ERC20Token>,
     ) -> Result<Self, Self::Error> {
         let liq = snapshot
             .state

--- a/src/evm/protocol/vm/adapter_contract.rs
+++ b/src/evm/protocol/vm/adapter_contract.rs
@@ -1,10 +1,11 @@
+use alloy_primitives::Address;
 use std::collections::{HashMap, HashSet};
 
 use ethers::{
-    abi::{Address, Token},
-    types::U256,
+    abi::Token,
+    types::{H160, U256},
 };
-use revm::{primitives::Address as rAddress, DatabaseRef};
+use revm::DatabaseRef;
 
 use crate::{
     evm::{
@@ -51,12 +52,12 @@ where
         buy_token: Address,
         amounts: Vec<U256>,
         block: u64,
-        overwrites: Option<HashMap<rAddress, Overwrites>>,
+        overwrites: Option<HashMap<Address, Overwrites>>,
     ) -> Result<Vec<f64>, SimulationError> {
         let args = vec![
             Token::FixedBytes(pair_id),
-            Token::Address(sell_token),
-            Token::Address(buy_token),
+            Token::Address(H160(sell_token.0 .0)),
+            Token::Address(H160(buy_token.0 .0)),
             Token::Array(
                 amounts
                     .into_iter()
@@ -81,12 +82,12 @@ where
         is_buy: bool,
         amount: U256,
         block: u64,
-        overwrites: Option<HashMap<rAddress, HashMap<U256, U256>>>,
+        overwrites: Option<HashMap<Address, HashMap<U256, U256>>>,
     ) -> Result<(Trade, HashMap<revm::precompile::Address, StateUpdate>), SimulationError> {
         let args = vec![
             Token::FixedBytes(pair_id),
-            Token::Address(sell_token),
-            Token::Address(buy_token),
+            Token::Address(H160(sell_token.0 .0)),
+            Token::Address(H160(buy_token.0 .0)),
             Token::Bool(is_buy),
             Token::Uint(amount),
         ];
@@ -135,10 +136,13 @@ where
         sell_token: Address,
         buy_token: Address,
         block: u64,
-        overwrites: Option<HashMap<rAddress, HashMap<U256, U256>>>,
+        overwrites: Option<HashMap<Address, HashMap<U256, U256>>>,
     ) -> Result<(U256, U256), SimulationError> {
-        let args =
-            vec![Token::FixedBytes(pair_id), Token::Address(sell_token), Token::Address(buy_token)];
+        let args = vec![
+            Token::FixedBytes(pair_id),
+            Token::Address(H160(sell_token.0 .0)),
+            Token::Address(H160(buy_token.0 .0)),
+        ];
 
         let res = self
             .call("getLimits", args, block, None, overwrites, None, U256::zero())?
@@ -164,8 +168,11 @@ where
         sell_token: Address,
         buy_token: Address,
     ) -> Result<HashSet<Capability>, SimulationError> {
-        let args =
-            vec![Token::FixedBytes(pair_id), Token::Address(sell_token), Token::Address(buy_token)];
+        let args = vec![
+            Token::FixedBytes(pair_id),
+            Token::Address(H160(sell_token.0 .0)),
+            Token::Address(H160(buy_token.0 .0)),
+        ];
 
         let res = self
             .call("getCapabilities", args, 1, None, None, None, U256::zero())?

--- a/src/evm/protocol/vm/erc20_token.rs
+++ b/src/evm/protocol/vm/erc20_token.rs
@@ -1,11 +1,12 @@
+use alloy_primitives::Address;
 use std::{collections::HashMap, str::FromStr};
 
 use ethers::{
-    abi::{Abi, Address, Token},
+    abi::{Abi, Token},
     types::{H160, U256},
 };
 use lazy_static::lazy_static;
-use revm::{primitives::Address as rAddress, DatabaseRef};
+use revm::DatabaseRef;
 use serde_json::from_str;
 
 use crate::{
@@ -40,7 +41,7 @@ impl ERC20Slots {
 pub type Overwrites = HashMap<SlotId, U256>;
 
 pub struct ERC20OverwriteFactory {
-    token_address: rAddress,
+    token_address: Address,
     overwrites: Overwrites,
     balance_slot: SlotId,
     allowance_slot: SlotId,
@@ -50,7 +51,7 @@ pub struct ERC20OverwriteFactory {
 
 impl ERC20OverwriteFactory {
     pub fn new(
-        token_address: rAddress,
+        token_address: Address,
         token_slots: ERC20Slots,
         compiler: ContractCompiler,
     ) -> Self {
@@ -84,7 +85,7 @@ impl ERC20OverwriteFactory {
             .insert(self.total_supply_slot, supply);
     }
 
-    pub fn get_overwrites(&self) -> HashMap<rAddress, Overwrites> {
+    pub fn get_overwrites(&self) -> HashMap<Address, Overwrites> {
         let mut result = HashMap::new();
         result.insert(self.token_address, self.overwrites.clone());
         result
@@ -138,7 +139,7 @@ lazy_static! {
 /// - Once the balance slot is found, it uses the detected compiler to search for the allowance
 ///   slot, which is dependent on the balance slot.
 pub fn brute_force_slots<D: EngineDatabaseInterface + Clone>(
-    token_addr: &H160,
+    token_addr: &Address,
     block: &BlockHeader,
     engine: &SimulationEngine<D>,
 ) -> Result<(ERC20Slots, ContractCompiler), SimulationError>
@@ -146,14 +147,8 @@ where
     <D as DatabaseRef>::Error: std::fmt::Debug,
     <D as EngineDatabaseInterface>::Error: std::fmt::Debug,
 {
-    let token_contract = TychoSimulationContract::new(
-        rAddress::from_slice(token_addr.as_bytes()),
-        engine.clone(),
-        ERC20_ABI.clone(),
-    )
-    .unwrap();
-
-    let external_account = H160::from_slice(&*EXTERNAL_ACCOUNT.0);
+    let token_contract =
+        TychoSimulationContract::new(*token_addr, engine.clone(), ERC20_ABI.clone()).unwrap();
 
     let mut compiler = ContractCompiler::Solidity;
 
@@ -161,16 +156,16 @@ where
     for i in 0..100 {
         for compiler_flag in [ContractCompiler::Solidity, ContractCompiler::Vyper] {
             let mut overwrite_factory = ERC20OverwriteFactory::new(
-                rAddress::from_slice(token_addr.as_bytes()),
+                *token_addr,
                 ERC20Slots::new(i.into(), 1.into()),
                 compiler_flag,
             );
-            overwrite_factory.set_balance(MARKER_VALUE.into(), external_account);
+            overwrite_factory.set_balance(MARKER_VALUE.into(), *EXTERNAL_ACCOUNT);
 
             let res = token_contract
                 .call(
                     "balanceOf",
-                    vec![Token::Address(external_account)],
+                    vec![Token::Address(H160::from_slice(&*EXTERNAL_ACCOUNT.0))],
                     block.number,
                     Some(block.timestamp),
                     Some(overwrite_factory.get_overwrites()),
@@ -197,7 +192,7 @@ where
     let mut allowance_slot = None;
     for i in 0..100 {
         let mut overwrite_factory = ERC20OverwriteFactory::new(
-            rAddress::from_slice(token_addr.as_bytes()),
+            *token_addr,
             ERC20Slots::new(0.into(), i.into()),
             compiler, /* At this point we know the compiler becase we managed to find the
                        * balance slot */
@@ -205,15 +200,15 @@ where
 
         overwrite_factory.set_allowance(
             MARKER_VALUE.into(),
-            H160::from_str(SPENDER).unwrap(),
-            external_account,
+            Address::from_str(SPENDER).unwrap(),
+            *EXTERNAL_ACCOUNT,
         );
 
         let res = token_contract
             .call(
                 "allowance",
                 vec![
-                    Token::Address(external_account),
+                    Token::Address(H160::from_slice(&*EXTERNAL_ACCOUNT.0)),
                     Token::Address(H160::from_str(SPENDER).unwrap()),
                 ],
                 block.number,
@@ -252,7 +247,7 @@ mod tests {
     use crate::evm::engine_db::simulation_db::SimulationDB;
 
     fn setup_factory() -> ERC20OverwriteFactory {
-        let token_address: rAddress = rAddress::from_slice(
+        let token_address: Address = Address::from_slice(
             &hex::decode("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
                 .expect("Invalid token address"),
         );
@@ -336,7 +331,7 @@ mod tests {
         };
 
         let (slots, compiler) = brute_force_slots(
-            &H160::from_str("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap(),
+            &Address::from_str("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap(),
             &block,
             &eng,
         )
@@ -365,7 +360,7 @@ mod tests {
         };
 
         let (slots, compiler) = brute_force_slots(
-            &H160::from_str("0xa5588f7cdf560811710a2d82d3c9c99769db1dcb").unwrap(),
+            &Address::from_str("0xa5588f7cdf560811710a2d82d3c9c99769db1dcb").unwrap(),
             &block,
             &eng,
         )

--- a/src/evm/protocol/vm/state.rs
+++ b/src/evm/protocol/vm/state.rs
@@ -5,10 +5,10 @@ use std::{
 };
 
 use alloy_primitives::Address;
-use ethers::{prelude::U256, types::H160};
+use ethers::prelude::U256;
 use itertools::Itertools;
 use num_bigint::BigUint;
-use revm::{precompile::Address as rAddress, primitives::U256 as rU256, DatabaseRef};
+use revm::{primitives::U256 as rU256, DatabaseRef};
 use tracing::info;
 
 use tycho_core::dto::ProtocolStateDelta;
@@ -47,30 +47,30 @@ where
     /// The pool's identifier
     id: String,
     /// The pool's token's addresses
-    pub tokens: Vec<H160>,
+    pub tokens: Vec<Address>,
     /// The current block, will be used to set vm context
     block: BlockHeader,
     /// The pools token balances
-    balances: HashMap<H160, U256>,
+    balances: HashMap<Address, U256>,
     /// The contract address for where protocol balances are stored (i.e. a vault contract).
     /// If given, balances will be overwritten here instead of on the pool contract during
     /// simulations
-    balance_owner: Option<H160>,
+    balance_owner: Option<Address>,
     /// Spot prices of the pool by token pair
-    spot_prices: HashMap<(H160, H160), f64>,
+    spot_prices: HashMap<(Address, Address), f64>,
     /// The supported capabilities of this pool
     capabilities: HashSet<Capability>,
     /// Storage overwrites that will be applied to all simulations. They will be cleared
     /// when ``clear_all_cache`` is called, i.e. usually at each block. Hence, the name.
-    block_lasting_overwrites: HashMap<rAddress, Overwrites>,
+    block_lasting_overwrites: HashMap<Address, Overwrites>,
     /// A set of all contract addresses involved in the simulation of this pool."""
-    involved_contracts: HashSet<H160>,
+    involved_contracts: HashSet<Address>,
     /// Allows the specification of custom storage slots for token allowances and
     /// balances. This is particularly useful for token contracts involved in protocol
     /// logic that extends beyond simple transfer functionality.
     /// Each entry also specify the compiler with which the target contract was compiled. This is
     /// later used to compute storage slot for maps.
-    token_storage_slots: HashMap<H160, (ERC20Slots, ContractCompiler)>,
+    token_storage_slots: HashMap<Address, (ERC20Slots, ContractCompiler)>,
     /// Indicates if the protocol uses custom update rules and requires update
     /// triggers to recalculate spot prices ect. Default is to update on all changes on
     /// the pool.
@@ -88,15 +88,15 @@ where
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: String,
-        tokens: Vec<H160>,
+        tokens: Vec<Address>,
         block: BlockHeader,
-        balances: HashMap<H160, U256>,
-        balance_owner: Option<H160>,
-        spot_prices: HashMap<(H160, H160), f64>,
+        balances: HashMap<Address, U256>,
+        balance_owner: Option<Address>,
+        spot_prices: HashMap<(Address, Address), f64>,
         capabilities: HashSet<Capability>,
-        block_lasting_overwrites: HashMap<rAddress, Overwrites>,
-        involved_contracts: HashSet<H160>,
-        token_storage_slots: HashMap<H160, (ERC20Slots, ContractCompiler)>,
+        block_lasting_overwrites: HashMap<Address, Overwrites>,
+        involved_contracts: HashSet<Address>,
+        token_storage_slots: HashMap<Address, (ERC20Slots, ContractCompiler)>,
         manual_updates: bool,
         adapter_contract: TychoSimulationContract<D>,
     ) -> Self {
@@ -179,7 +179,7 @@ where
     /// is significant and determines the direction of the price query.
     fn get_sell_amount_limit(
         &self,
-        tokens: Vec<H160>,
+        tokens: Vec<Address>,
         overwrites: Option<HashMap<Address, HashMap<U256, U256>>>,
     ) -> Result<U256, SimulationError> {
         let pool_id_vec = hexstring_to_vec(&self.id.clone())?;
@@ -205,9 +205,9 @@ where
 
     fn get_overwrites(
         &self,
-        tokens: Vec<H160>,
+        tokens: Vec<Address>,
         max_amount: U256,
-    ) -> Result<HashMap<rAddress, Overwrites>, SimulationError> {
+    ) -> Result<HashMap<Address, Overwrites>, SimulationError> {
         let token_overwrites = self.get_token_overwrites(tokens, max_amount)?;
 
         // Merge `block_lasting_overwrites` with `token_overwrites`
@@ -219,11 +219,11 @@ where
 
     fn get_token_overwrites(
         &self,
-        tokens: Vec<H160>,
+        tokens: Vec<Address>,
         max_amount: U256,
-    ) -> Result<HashMap<rAddress, Overwrites>, SimulationError> {
+    ) -> Result<HashMap<Address, Overwrites>, SimulationError> {
         let sell_token = &tokens[0].clone();
-        let mut res: Vec<HashMap<rAddress, Overwrites>> = Vec::new();
+        let mut res: Vec<HashMap<Address, Overwrites>> = Vec::new();
         if !self
             .capabilities
             .contains(&Capability::TokenBalanceIndependent)
@@ -240,19 +240,15 @@ where
                 ContractCompiler::Solidity,
             ));
 
-        let mut overwrites = ERC20OverwriteFactory::new(
-            rAddress::from_slice(&sell_token.0),
-            slots.clone(),
-            compiler,
-        );
+        let mut overwrites = ERC20OverwriteFactory::new(*sell_token, slots.clone(), compiler);
 
-        overwrites.set_balance(max_amount, H160::from_slice(&*EXTERNAL_ACCOUNT.0));
+        overwrites.set_balance(max_amount, Address::from_slice(&*EXTERNAL_ACCOUNT.0));
 
         // Set allowance for ADAPTER_ADDRESS to max_amount
         overwrites.set_allowance(
             max_amount,
-            H160::from_slice(&*ADAPTER_ADDRESS.0),
-            H160::from_slice(&*EXTERNAL_ACCOUNT.0),
+            Address::from_slice(&*ADAPTER_ADDRESS.0),
+            Address::from_slice(&*EXTERNAL_ACCOUNT.0),
         );
 
         res.push(overwrites.get_overwrites());
@@ -265,9 +261,9 @@ where
 
     fn get_balance_overwrites(
         &self,
-        tokens: Vec<H160>,
-    ) -> Result<HashMap<rAddress, Overwrites>, SimulationError> {
-        let mut balance_overwrites: HashMap<rAddress, Overwrites> = HashMap::new();
+        tokens: Vec<Address>,
+    ) -> Result<HashMap<Address, Overwrites>, SimulationError> {
+        let mut balance_overwrites: HashMap<Address, Overwrites> = HashMap::new();
         let address = match self.balance_owner {
             Some(address) => Ok(address),
             None => self.id.parse().map_err(|_| {
@@ -293,7 +289,7 @@ where
             };
 
             let mut overwrites =
-                ERC20OverwriteFactory::new(rAddress::from(token.0), slots, compiler);
+                ERC20OverwriteFactory::new(Address::from(token.0), slots, compiler);
             overwrites.set_balance(
                 self.balances
                     .get(token)
@@ -316,9 +312,9 @@ where
 
     fn merge(
         &self,
-        target: &HashMap<rAddress, Overwrites>,
-        source: &HashMap<rAddress, Overwrites>,
-    ) -> HashMap<rAddress, Overwrites> {
+        target: &HashMap<Address, Overwrites>,
+        source: &HashMap<Address, Overwrites>,
+    ) -> HashMap<Address, Overwrites> {
         let mut merged = target.clone();
 
         for (key, source_inner) in source {
@@ -332,7 +328,7 @@ where
     }
 
     #[cfg(test)]
-    pub fn get_involved_contracts(&self) -> HashSet<H160> {
+    pub fn get_involved_contracts(&self) -> HashSet<Address> {
         self.involved_contracts.clone()
     }
 
@@ -342,7 +338,7 @@ where
     }
 
     #[cfg(test)]
-    pub fn get_balance_owner(&self) -> Option<H160> {
+    pub fn get_balance_owner(&self) -> Option<Address> {
         self.balance_owner
     }
 }
@@ -515,7 +511,7 @@ mod tests {
         str::FromStr,
     };
 
-    use ethers::{prelude::H256, types::Address as EthAddress};
+    use ethers::prelude::H256;
     use num_bigint::ToBigUint;
     use num_traits::One;
     use revm::primitives::{AccountInfo, Bytecode, KECCAK_EMPTY};
@@ -605,14 +601,12 @@ mod tests {
         )]);
 
         let balances = HashMap::from([
-            (EthAddress::from(dai_addr.0), U256::from_dec_str("178754012737301807104").unwrap()),
-            (EthAddress::from(bal_addr.0), U256::from_dec_str("91082987763369885696").unwrap()),
+            (dai_addr, U256::from_dec_str("178754012737301807104").unwrap()),
+            (bal_addr, U256::from_dec_str("91082987763369885696").unwrap()),
         ]);
 
         EVMPoolStateBuilder::new(pool_id, tokens, balances, block)
-            .balance_owner(
-                EthAddress::from_str("0xBA12222222228d8Ba445958a75a0704d566BF2C8").unwrap(),
-            )
+            .balance_owner(Address::from_str("0xBA12222222228d8Ba445958a75a0704d566BF2C8").unwrap())
             .adapter_contract_path(PathBuf::from(
                 "src/evm/protocol/vm/assets/BalancerSwapAdapter.evm.runtime".to_string(),
             ))
@@ -668,9 +662,8 @@ mod tests {
             .clone()
             .get_account_storage();
         for token in pool_state.tokens.clone() {
-            let token_address = rAddress::from_slice(&token.0);
             let account = engine_accounts
-                .get_account_info(&token_address)
+                .get_account_info(&token)
                 .unwrap();
             assert_eq!(account.balance, rU256::from(0));
             assert_eq!(account.nonce, 0u64);

--- a/src/evm/protocol/vm/utils.rs
+++ b/src/evm/protocol/vm/utils.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::Address;
 use std::{
     collections::HashMap,
     env,
@@ -12,7 +13,7 @@ use ethers::{
     abi::Abi,
     prelude::ProviderError,
     providers::{Http, Middleware, Provider},
-    types::{Address, H160},
+    types::H160,
 };
 use hex::FromHex;
 use mini_moka::sync::Cache;
@@ -188,7 +189,7 @@ pub fn get_storage_slot_index_at_key(
     mapping_slot: SlotId,
     compiler: ContractCompiler,
 ) -> SlotId {
-    let mut key_bytes = key.as_bytes().to_vec();
+    let mut key_bytes = key.as_slice().to_vec();
     if key_bytes.len() < 32 {
         let padding = vec![0u8; 32 - key_bytes.len()];
         key_bytes.splice(0..0, padding); // Prepend zeros to the start

--- a/src/models.rs
+++ b/src/models.rs
@@ -5,22 +5,22 @@
 //!
 //! ERC20Tokens provide instructions on how to handle prices and amounts,
 //! while Swap and SwapSequence are usually used as results types.
+use alloy_primitives::Address;
 use std::{
     convert::TryFrom,
     hash::{Hash, Hasher},
     str::FromStr,
 };
 
-use ethers::types::{H160, U256};
+use ethers::types::U256;
 use num_bigint::BigUint;
 
 use tycho_core::dto::ResponseToken;
-use tycho_ethereum::BytesCodec;
 
 #[derive(Clone, Debug, Eq)]
 pub struct ERC20Token {
     /// The address of the token on the blockchain network
-    pub address: H160,
+    pub address: Address,
     /// The number of decimal places that the token uses
     pub decimals: usize,
     /// The symbol of the token
@@ -46,7 +46,7 @@ impl ERC20Token {
     /// ## Panic
     /// - Panics if the token address string is not in valid format
     pub fn new(address: &str, decimals: usize, symbol: &str, gas: BigUint) -> Self {
-        let addr = H160::from_str(address).expect("Failed to parse token address");
+        let addr = Address::from_str(address).expect("Failed to parse token address");
         let sym = symbol.to_string();
         ERC20Token { address: addr, decimals, symbol: sym, gas }
     }
@@ -84,7 +84,7 @@ impl TryFrom<ResponseToken> for ERC20Token {
 
     fn try_from(value: ResponseToken) -> Result<Self, Self::Error> {
         Ok(Self {
-            address: H160::from_bytes(&value.address),
+            address: Address::from_slice(&value.address),
             decimals: value.decimals.try_into()?,
             symbol: value.symbol,
             gas: BigUint::from(

--- a/src/protocol/models.rs
+++ b/src/protocol/models.rs
@@ -24,6 +24,7 @@
 //! It's worth emphasizin that although the term "pair" used in this
 //! module refers to a trading pair, it does not necessarily imply two
 //! tokens only. Some pairs might have more than two tokens.
+use alloy_primitives::Address;
 use std::collections::HashMap;
 
 use num_bigint::BigUint;
@@ -62,7 +63,7 @@ pub trait TryFromWithBlock<T> {
     async fn try_from_with_block(
         value: T,
         block: Header,
-        all_tokens: HashMap<Bytes, ERC20Token>,
+        all_tokens: HashMap<Address, ERC20Token>,
     ) -> Result<Self, Self::Error>
     where
         Self: Sized;


### PR DESCRIPTION
Also change the VMPoolState attributes to be Address instead of H160

TODO: (in the upcoming episodes):
- Replace ethers U256 with alloy U256 in the vm pool state
- Abstract away ERC20Token logic (this one is evm specific)
- Use alloy to encode and decode instead of ethers (in simulation contract)
