### PR TITLE
chore: update default TYCHO_URL to point to beta environment

### DIFF
--- a/examples/explorer/main.rs
+++ b/examples/explorer/main.rs
@@ -34,7 +34,7 @@ async fn main() {
     let cli = Cli::parse();
 
     let tycho_url =
-        env::var("TYCHO_URL").unwrap_or_else(|_| "tycho-dev.propellerheads.xyz".to_string());
+        env::var("TYCHO_URL").unwrap_or_else(|_| "tycho-beta.propellerheads.xyz".to_string());
     let tycho_api_key: String =
         env::var("TYCHO_API_KEY").unwrap_or_else(|_| "sampletoken".to_string());
 


### PR DESCRIPTION
After the recent Tycho prod update, we can point to beta endpoint again