### PR TITLE
fix: Move load_all_tokens to simulation's utils

### DIFF
--- a/examples/explorer/main.rs
+++ b/examples/explorer/main.rs
@@ -3,7 +3,6 @@ pub mod utils;
 
 extern crate tycho_simulation;
 
-use crate::utils::load_all_tokens;
 use clap::Parser;
 use futures::{future::select_all, StreamExt};
 use std::env;
@@ -22,6 +21,7 @@ use tycho_simulation::{
         stream::ProtocolStreamBuilder,
     },
     protocol::models::BlockUpdate,
+    utils::load_all_tokens,
 };
 
 #[derive(Parser)]

--- a/examples/explorer/utils.rs
+++ b/examples/explorer/utils.rs
@@ -1,31 +1,4 @@
-use std::collections::HashMap;
-
 use tracing_subscriber::{fmt, EnvFilter};
-use tycho_client::{rpc::RPCClient, HttpRPCClient};
-use tycho_core::{dto::Chain, Bytes};
-use tycho_simulation::models::Token;
-
-pub async fn load_all_tokens(tycho_url: &str, auth_key: Option<&str>) -> HashMap<Bytes, Token> {
-    let rpc_url = format!("https://{tycho_url}");
-    let rpc_client = HttpRPCClient::new(rpc_url.as_str(), auth_key).unwrap();
-
-    #[allow(clippy::mutable_key_type)]
-    rpc_client
-        .get_all_tokens(Chain::Ethereum, Some(100), Some(42), 3_000)
-        .await
-        .expect("Unable to load tokens")
-        .into_iter()
-        .map(|token| {
-            let token_clone = token.clone();
-            (
-                token.address.clone(),
-                token.try_into().unwrap_or_else(|_| {
-                    panic!("Couldn't convert {:?} into ERC20 token.", token_clone)
-                }),
-            )
-        })
-        .collect::<HashMap<_, Token>>()
-}
 
 pub fn setup_tracing() {
     let writer = tracing_appender::rolling::daily("logs", "explorer.log");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,4 +24,4 @@ pub mod evm;
 pub mod models;
 pub mod protocol;
 pub mod serde_helpers;
-pub(crate) mod utils;
+pub mod utils;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,7 @@
-use crate::protocol::errors::SimulationError;
+use crate::{models::Token, protocol::errors::SimulationError};
+use std::collections::HashMap;
+use tycho_client::{rpc::RPCClient, HttpRPCClient};
+use tycho_core::{dto::Chain, Bytes};
 
 /// Converts a hexadecimal string into a `Vec<u8>`.
 ///
@@ -28,4 +31,26 @@ pub fn hexstring_to_vec(hexstring: &str) -> Result<Vec<u8>, SimulationError> {
     let bytes = hex::decode(hexstring_no_prefix)
         .map_err(|_| SimulationError::FatalError(format!("Invalid hex string: {}", hexstring)))?;
     Ok(bytes)
+}
+
+pub async fn load_all_tokens(tycho_url: &str, auth_key: Option<&str>) -> HashMap<Bytes, Token> {
+    let rpc_url = format!("https://{tycho_url}");
+    let rpc_client = HttpRPCClient::new(rpc_url.as_str(), auth_key).unwrap();
+
+    #[allow(clippy::mutable_key_type)]
+    rpc_client
+        .get_all_tokens(Chain::Ethereum, Some(100), Some(42), 3_000)
+        .await
+        .expect("Unable to load tokens")
+        .into_iter()
+        .map(|token| {
+            let token_clone = token.clone();
+            (
+                token.address.clone(),
+                token.try_into().unwrap_or_else(|_| {
+                    panic!("Couldn't convert {:?} into ERC20 token.", token_clone)
+                }),
+            )
+        })
+        .collect::<HashMap<_, Token>>()
 }


### PR DESCRIPTION
This is needed for the quickstart example!