### PR TITLE
feat: Add tokens to ProtocolSim and use them for validations

### DIFF
--- a/src/evm/protocol/uniswap_v2/tycho_decoder.rs
+++ b/src/evm/protocol/uniswap_v2/tycho_decoder.rs
@@ -35,8 +35,9 @@ impl TryFromWithBlock<ComponentWithState> for UniswapV2State {
                 .get("reserve1")
                 .ok_or(InvalidSnapshotError::MissingAttribute("reserve1".to_string()))?,
         );
+        let tokens = snapshot.component.tokens.clone();
 
-        Ok(UniswapV2State::new(reserve0, reserve1))
+        Ok(UniswapV2State::new(reserve0, reserve1, tokens))
     }
 }
 

--- a/src/evm/protocol/uniswap_v3/tycho_decoder.rs
+++ b/src/evm/protocol/uniswap_v3/tycho_decoder.rs
@@ -119,7 +119,9 @@ impl TryFromWithBlock<ComponentWithState> for UniswapV3State {
 
         ticks.sort_by_key(|tick| tick.index);
 
-        Ok(UniswapV3State::new(liquidity, sqrt_price, fee, tick, ticks))
+        let tokens = snapshot.component.tokens.clone();
+
+        Ok(UniswapV3State::new(liquidity, sqrt_price, fee, tick, ticks, tokens))
     }
 }
 
@@ -224,6 +226,7 @@ mod tests {
             FeeAmount::Medium,
             300,
             vec![TickInfo::new(60, 400)],
+            vec![],
         );
         assert_eq!(result.unwrap(), expected);
     }


### PR DESCRIPTION
In every get_amount and spot_prices we are now validating the tokens that are passed. This way, the user can't call these methods with random tokens and get a silently wrong result (no warning or error)
