### PR TITLE
fix: Allow for no tls connections when getting tokens from Tycho

### DIFF
--- a/.github/workflows/tests-and-lints-template.yaml
+++ b/.github/workflows/tests-and-lints-template.yaml
@@ -70,7 +70,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Test
-        run: cargo nextest run --workspace --lib --all-targets --all-features
+        run: cargo nextest run --workspace --lib --all-targets --all-features && cargo test --doc
 
   lint:
     name: Code Lint

--- a/examples/price_printer/main.rs
+++ b/examples/price_printer/main.rs
@@ -47,7 +47,8 @@ async fn main() {
     let (tick_tx, tick_rx) = mpsc::channel::<BlockUpdate>(12);
 
     let tycho_message_processor: JoinHandle<anyhow::Result<()>> = tokio::spawn(async move {
-        let all_tokens = load_all_tokens(tycho_url.as_str(), Some(tycho_api_key.as_str())).await;
+        let all_tokens =
+            load_all_tokens(tycho_url.as_str(), false, Some(tycho_api_key.as_str())).await;
         let tvl_filter = ComponentFilter::with_tvl_range(cli.tvl_threshold, cli.tvl_threshold);
         let mut protocol_stream = ProtocolStreamBuilder::new(&tycho_url, Chain::Ethereum)
             .exchange::<UniswapV2State>("uniswap_v2", tvl_filter.clone(), None)

--- a/examples/quickstart/main.rs
+++ b/examples/quickstart/main.rs
@@ -34,7 +34,7 @@ async fn main() {
     let tvl_threshold = 10_000.0;
     let tvl_filter = ComponentFilter::with_tvl_range(tvl_threshold, tvl_threshold);
 
-    let all_tokens = load_all_tokens(tycho_url.as_str(), Some(tycho_api_key.as_str())).await;
+    let all_tokens = load_all_tokens(tycho_url.as_str(), false, Some(tycho_api_key.as_str())).await;
     let mut pairs: HashMap<String, Vec<Token>> = HashMap::new();
 
     let mut protocol_stream = ProtocolStreamBuilder::new(&tycho_url, Chain::Ethereum)

--- a/src/evm/protocol/uniswap_v2/reserve_price.rs
+++ b/src/evm/protocol/uniswap_v2/reserve_price.rs
@@ -8,16 +8,6 @@ use crate::evm::protocol::u256_num::u256_to_f64;
 ///     1. The nominator and denominator are converted to float (this conversion is lossy)
 ///     2. The price is computed by using float division
 ///     3. Finally, the price is correct for difference in token decimals.
-///
-/// # Example
-/// ```
-/// use alloy_primitives::U256;
-/// use tycho_simulation::evm::protocol::uniswap_v2::reserve_price::spot_price_from_reserves;
-///
-/// let res = spot_price_from_reserves(U256::from(100), U256::from(200), 6, 6);
-///
-/// assert_eq!(res, 2.0f64);
-/// ```
 pub(super) fn spot_price_from_reserves(
     r0: U256,
     r1: U256,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -36,8 +36,13 @@ pub fn hexstring_to_vec(hexstring: &str) -> Result<Vec<u8>, SimulationError> {
 }
 
 /// Loads all tokens from Tycho and returns them as a Hashmap of address->Token.
-pub async fn load_all_tokens(tycho_url: &str, auth_key: Option<&str>) -> HashMap<Bytes, Token> {
-    let rpc_url = format!("https://{tycho_url}");
+pub async fn load_all_tokens(
+    tycho_url: &str,
+    no_tls: bool,
+    auth_key: Option<&str>,
+) -> HashMap<Bytes, Token> {
+    let rpc_url =
+        if no_tls { format!("http://{tycho_url}") } else { format!("https://{tycho_url}") };
     let rpc_client = HttpRPCClient::new(rpc_url.as_str(), auth_key).unwrap();
 
     #[allow(clippy::mutable_key_type)]


### PR DESCRIPTION
This is necessary to run in the cluster
