### PR TITLE
refactor(example): early error if `RPC_URL` isn't set in `price_printer`

### DIFF
--- a/examples/price_printer/main.rs
+++ b/examples/price_printer/main.rs
@@ -43,6 +43,11 @@ async fn main() {
     let tycho_api_key: String =
         env::var("TYCHO_API_KEY").unwrap_or_else(|_| "sampletoken".to_string());
 
+    // Perform an early check to ensure `RPC_URL` is set.
+    // This prevents errors from occurring later during UI interactions.
+    // Can be commented out if only using the example with uniswap_v2 and uniswap_v3.
+    env::var("RPC_URL").expect("RPC_URL env variable should be set");
+
     // Create communication channels for inter-thread communication
     let (tick_tx, tick_rx) = mpsc::channel::<BlockUpdate>(12);
 


### PR DESCRIPTION
This way, users will get a clear error message if they forgot to set `RPC_URL`. This variable isn't needed for uniswaps but Curve and Balancer are on by default so we enforce it by default.