### PR TITLE
feat: Refactor quickstart and add execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7874,8 +7874,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.51.0"
-source = "git+https://github.com/propeller-heads/tycho-execution.git?rev=5aec1c08117c249ebe68421367ad6a68636fca9b#5aec1c08117c249ebe68421367ad6a68636fca9b"
+version = "0.53.0"
+source = "git+https://github.com/propeller-heads/tycho-execution.git?rev=05a1843f9c3f916d4af8fbf67cccf3b3b94aeab8#05a1843f9c3f916d4af8fbf67cccf3b3b94aeab8"
 dependencies = [
  "alloy 0.9.2",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 name = "_tycho_simulation_py"
 version = "0.77.2"
 dependencies = [
- "alloy",
+ "alloy 0.5.4",
  "num-bigint",
  "pyo3",
  "pyo3-log",
@@ -87,16 +87,40 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea8ebf106e84a1c37f86244df7da0c7587e697b71a0d565cce079449b85ac6f8"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.5.4",
  "alloy-core",
- "alloy-eips",
- "alloy-genesis",
- "alloy-network",
- "alloy-provider",
- "alloy-rpc-client",
- "alloy-serde",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-eips 0.5.4",
+ "alloy-genesis 0.5.4",
+ "alloy-network 0.5.4",
+ "alloy-provider 0.5.4",
+ "alloy-rpc-client 0.5.4",
+ "alloy-serde 0.5.4",
+ "alloy-transport 0.5.4",
+ "alloy-transport-http 0.5.4",
+]
+
+[[package]]
+name = "alloy"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbcc41e8a11a4975b18ec6afba2cc48d591fa63336a4c526dacb50479a8d6b35"
+dependencies = [
+ "alloy-consensus 0.9.2",
+ "alloy-core",
+ "alloy-eips 0.9.2",
+ "alloy-genesis 0.9.2",
+ "alloy-network 0.9.2",
+ "alloy-provider 0.9.2",
+ "alloy-rpc-client 0.9.2",
+ "alloy-rpc-types 0.9.2",
+ "alloy-serde 0.9.2",
+ "alloy-signer 0.9.2",
+ "alloy-signer-aws",
+ "alloy-signer-gcp",
+ "alloy-signer-ledger 0.9.2",
+ "alloy-signer-local 0.9.2",
+ "alloy-transport 0.9.2",
+ "alloy-transport-http 0.9.2",
 ]
 
 [[package]]
@@ -117,13 +141,44 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41ed961a48297c732a5d97ee321aa8bb5009ecadbcb077d8bec90cb54e651629"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.5.4",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.5.4",
  "auto_impl",
  "c-kzg",
  "derive_more",
+ "serde",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4138dc275554afa6f18c4217262ac9388790b2fc393c2dfe03c51d357abf013"
+dependencies = [
+ "alloy-eips 0.9.2",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.9.2",
+ "alloy-trie",
+ "auto_impl",
+ "c-kzg",
+ "derive_more",
+ "serde",
+]
+
+[[package]]
+name = "alloy-consensus-any"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa04e1882c31288ce1028fdf31b6ea94cfa9eafa2e497f903ded631c8c6a42c"
+dependencies = [
+ "alloy-consensus 0.9.2",
+ "alloy-eips 0.9.2",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.9.2",
  "serde",
 ]
 
@@ -135,13 +190,13 @@ checksum = "460ab80ce4bda1c80bcf96fe7460520476f2c7b734581c6567fac2708e2a60ef"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
- "alloy-network",
- "alloy-network-primitives",
+ "alloy-network 0.5.4",
+ "alloy-network-primitives 0.5.4",
  "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types-eth",
+ "alloy-provider 0.5.4",
+ "alloy-rpc-types-eth 0.5.4",
  "alloy-sol-types",
- "alloy-transport",
+ "alloy-transport 0.5.4",
  "futures 0.3.31",
  "futures-util",
  "thiserror 1.0.69",
@@ -210,16 +265,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-eip7702"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabf647eb4650c91a9d38cb6f972bb320009e7e9d61765fb688a86f1563b33e8"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more",
+ "serde",
+]
+
+[[package]]
 name = "alloy-eips"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b69e06cf9c37be824b9d26d6d101114fdde6af0c87de2828b414c05c4b3daa71"
 dependencies = [
  "alloy-eip2930",
- "alloy-eip7702",
+ "alloy-eip7702 0.3.2",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.5.4",
+ "c-kzg",
+ "derive_more",
+ "once_cell",
+ "serde",
+ "sha2",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dd5869ed09e399003e0e0ec6903d981b2a92e74c5d37e6b40890bad2517526"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702 0.5.0",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.9.2",
  "c-kzg",
  "derive_more",
  "once_cell",
@@ -234,7 +319,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde15e14944a88bd6a57d325e9a49b75558746fe16aaccc79713ae50a6a9574c"
 dependencies = [
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 0.5.4",
+ "serde",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d2a7fe5c1a9bd6793829ea21a636f30fc2b3f5d2e7418ba86d96e41dd1f460"
+dependencies = [
+ "alloy-eips 0.9.2",
+ "alloy-primitives",
+ "alloy-serde 0.9.2",
+ "alloy-trie",
  "serde",
 ]
 
@@ -265,19 +363,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-json-rpc"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2008bedb8159a255b46b7c8614516eda06679ea82f620913679afbd8031fea72"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.6",
+ "tracing",
+]
+
+[[package]]
 name = "alloy-network"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "204237129086ce5dc17a58025e93739b01b45313841f98fa339eb1d780511e57"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-json-rpc",
- "alloy-network-primitives",
+ "alloy-consensus 0.5.4",
+ "alloy-eips 0.5.4",
+ "alloy-json-rpc 0.5.4",
+ "alloy-network-primitives 0.5.4",
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "alloy-signer",
+ "alloy-rpc-types-eth 0.5.4",
+ "alloy-serde 0.5.4",
+ "alloy-signer 0.5.4",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
@@ -286,15 +398,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-network"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4556f01fe41d0677495df10a648ddcf7ce118b0e8aa9642a0e2b6dd1fb7259de"
+dependencies = [
+ "alloy-consensus 0.9.2",
+ "alloy-consensus-any",
+ "alloy-eips 0.9.2",
+ "alloy-json-rpc 0.9.2",
+ "alloy-network-primitives 0.9.2",
+ "alloy-primitives",
+ "alloy-rpc-types-any",
+ "alloy-rpc-types-eth 0.9.2",
+ "alloy-serde 0.9.2",
+ "alloy-signer 0.9.2",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.6",
+]
+
+[[package]]
 name = "alloy-network-primitives"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514f70ee2a953db21631cd817b13a1571474ec77ddc03d47616d5e8203489fde"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.5.4",
+ "alloy-eips 0.5.4",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 0.5.4",
+ "serde",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31c3c6b71340a1d076831823f09cb6e02de01de5c6630a9631bdb36f947ff80"
+dependencies = [
+ "alloy-consensus 0.9.2",
+ "alloy-eips 0.9.2",
+ "alloy-primitives",
+ "alloy-serde 0.9.2",
  "serde",
 ]
 
@@ -315,7 +465,7 @@ dependencies = [
  "getrandom",
  "hashbrown 0.15.2",
  "hex-literal",
- "indexmap",
+ "indexmap 2.7.0",
  "itoa",
  "k256",
  "keccak-asm",
@@ -337,16 +487,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4814d141ede360bb6cd1b4b064f1aab9de391e7c4d0d4d50ac89ea4bc1e25fbd"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
- "alloy-json-rpc",
- "alloy-network",
- "alloy-network-primitives",
+ "alloy-consensus 0.5.4",
+ "alloy-eips 0.5.4",
+ "alloy-json-rpc 0.5.4",
+ "alloy-network 0.5.4",
+ "alloy-network-primitives 0.5.4",
  "alloy-primitives",
- "alloy-rpc-client",
- "alloy-rpc-types-eth",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-rpc-client 0.5.4",
+ "alloy-rpc-types-eth 0.5.4",
+ "alloy-transport 0.5.4",
+ "alloy-transport-http 0.5.4",
  "async-stream",
  "async-trait",
  "auto_impl",
@@ -355,7 +505,7 @@ dependencies = [
  "futures-utils-wasm",
  "lru",
  "parking_lot",
- "pin-project",
+ "pin-project 1.1.7",
  "reqwest 0.12.9",
  "schnellru",
  "serde",
@@ -364,7 +514,44 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "wasmtimer",
+ "wasmtimer 0.2.1",
+]
+
+[[package]]
+name = "alloy-provider"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22c4441b3ebe2d77fa9cf629ba68c3f713eb91779cff84275393db97eddd82"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus 0.9.2",
+ "alloy-eips 0.9.2",
+ "alloy-json-rpc 0.9.2",
+ "alloy-network 0.9.2",
+ "alloy-network-primitives 0.9.2",
+ "alloy-primitives",
+ "alloy-rpc-client 0.9.2",
+ "alloy-rpc-types-eth 0.9.2",
+ "alloy-transport 0.9.2",
+ "alloy-transport-http 0.9.2",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap 6.1.0",
+ "futures 0.3.31",
+ "futures-utils-wasm",
+ "lru",
+ "parking_lot",
+ "pin-project 1.1.7",
+ "reqwest 0.12.9",
+ "schnellru",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.6",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtimer 0.4.1",
 ]
 
 [[package]]
@@ -373,9 +560,9 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96ba46eb69ddf7a9925b81f15229cb74658e6eebe5dd30a5b74e2cd040380573"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.5.4",
  "alloy-primitives",
- "alloy-transport",
+ "alloy-transport 0.5.4",
  "bimap",
  "futures 0.3.31",
  "serde",
@@ -414,12 +601,12 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc2bd1e7403463a5f2c61e955bcc9d3072b63aa177442b0f9aa6a6d22a941e3"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.5.4",
  "alloy-primitives",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 0.5.4",
+ "alloy-transport-http 0.5.4",
  "futures 0.3.31",
- "pin-project",
+ "pin-project 1.1.7",
  "reqwest 0.12.9",
  "serde",
  "serde_json",
@@ -428,7 +615,30 @@ dependencies = [
  "tower 0.5.1",
  "tracing",
  "url",
- "wasmtimer",
+ "wasmtimer 0.2.1",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06a292b37e182e514903ede6e623b9de96420e8109ce300da288a96d88b7e4b"
+dependencies = [
+ "alloy-json-rpc 0.9.2",
+ "alloy-primitives",
+ "alloy-transport 0.9.2",
+ "alloy-transport-http 0.9.2",
+ "futures 0.3.31",
+ "pin-project 1.1.7",
+ "reqwest 0.12.9",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.1",
+ "tracing",
+ "url",
+ "wasmtimer 0.4.1",
 ]
 
 [[package]]
@@ -439,9 +649,32 @@ checksum = "eea9bf1abdd506f985a53533f5ac01296bcd6102c5e139bbc5d40bc468d2c916"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 0.5.4",
+ "alloy-serde 0.5.4",
  "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9383845dd924939e7ab0298bbfe231505e20928907d7905aa3bf112287305e06"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth 0.9.2",
+ "alloy-serde 0.9.2",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca445cef0eb6c2cf51cfb4e214fbf1ebd00893ae2e6f3b944c8101b07990f988"
+dependencies = [
+ "alloy-consensus-any",
+ "alloy-rpc-types-eth 0.9.2",
+ "alloy-serde 0.9.2",
 ]
 
 [[package]]
@@ -450,11 +683,11 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "886d22d41992287a235af2f3af4299b5ced2bcafb81eb835572ad35747476946"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.5.4",
+ "alloy-eips 0.5.4",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.5.4",
  "derive_more",
  "jsonwebtoken 9.3.0",
  "rand",
@@ -468,17 +701,37 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b034779a4850b4b03f5be5ea674a1cf7d746b2da762b34d1860ab45e48ca27"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-network-primitives",
+ "alloy-consensus 0.5.4",
+ "alloy-eips 0.5.4",
+ "alloy-network-primitives 0.5.4",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.5.4",
  "alloy-sol-types",
  "derive_more",
  "itertools 0.13.0",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0938bc615c02421bd86c1733ca7205cc3d99a122d9f9bff05726bd604b76a5c2"
+dependencies = [
+ "alloy-consensus 0.9.2",
+ "alloy-consensus-any",
+ "alloy-eips 0.9.2",
+ "alloy-network-primitives 0.9.2",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.9.2",
+ "alloy-sol-types",
+ "itertools 0.13.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.6",
 ]
 
 [[package]]
@@ -488,8 +741,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e5fb6c5c401321f802f69dcdb95b932f30f8158f6798793f914baac5995628e"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 0.5.4",
+ "alloy-serde 0.5.4",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -500,6 +753,17 @@ name = "alloy-serde"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "028e72eaa9703e4882344983cfe7636ce06d8cce104a78ea62fd19b46659efc4"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae0465c71d4dced7525f408d84873aeebb71faf807d22d74c4a426430ccd9b55"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -523,16 +787,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-signer"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bfa395ad5cc952c82358d31e4c68b27bf4a89a5456d9b27e226e77dac50e4ff"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "elliptic-curve",
+ "k256",
+ "thiserror 2.0.6",
+]
+
+[[package]]
+name = "alloy-signer-aws"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb06810c34427d499863817eb506acf57cb9ded9224b374116cae4e22dbd4e9"
+dependencies = [
+ "alloy-consensus 0.9.2",
+ "alloy-network 0.9.2",
+ "alloy-primitives",
+ "alloy-signer 0.9.2",
+ "async-trait",
+ "aws-sdk-kms",
+ "k256",
+ "spki",
+ "thiserror 2.0.6",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-signer-gcp"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d629e63fec8802ad53706d46e8eceeeae2b135c6648d0de41669a523bf17df4a"
+dependencies = [
+ "alloy-consensus 0.9.2",
+ "alloy-network 0.9.2",
+ "alloy-primitives",
+ "alloy-signer 0.9.2",
+ "async-trait",
+ "gcloud-sdk",
+ "k256",
+ "spki",
+ "thiserror 2.0.6",
+ "tracing",
+]
+
+[[package]]
 name = "alloy-signer-ledger"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59a642c9f66ac73ae0d5398ce7ce3ce5bdfad5658d549abd48ea48962e585dca"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.5.4",
  "alloy-dyn-abi",
- "alloy-network",
+ "alloy-network 0.5.4",
  "alloy-primitives",
- "alloy-signer",
+ "alloy-signer 0.5.4",
  "alloy-sol-types",
  "async-trait",
  "coins-ledger",
@@ -543,15 +859,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-signer-ledger"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b426789566a19252cb46b757d91543a6f8e70330c72f312b86c5878595d092ef"
+dependencies = [
+ "alloy-consensus 0.9.2",
+ "alloy-dyn-abi",
+ "alloy-network 0.9.2",
+ "alloy-primitives",
+ "alloy-signer 0.9.2",
+ "alloy-sol-types",
+ "async-trait",
+ "coins-ledger",
+ "futures-util",
+ "semver 1.0.23",
+ "thiserror 2.0.6",
+ "tracing",
+]
+
+[[package]]
 name = "alloy-signer-local"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6614f02fc1d5b079b2a4a5320018317b506fd0a6d67c1fd5542a71201724986c"
 dependencies = [
- "alloy-consensus",
- "alloy-network",
+ "alloy-consensus 0.5.4",
+ "alloy-network 0.5.4",
  "alloy-primitives",
- "alloy-signer",
+ "alloy-signer 0.5.4",
  "async-trait",
  "coins-bip32",
  "coins-bip39",
@@ -562,15 +898,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-signer-local"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdc63ce9eda1283fcbaca66ba4a414b841c0e3edbeef9c86a71242fc9e84ccc"
+dependencies = [
+ "alloy-consensus 0.9.2",
+ "alloy-network 0.9.2",
+ "alloy-primitives",
+ "alloy-signer 0.9.2",
+ "async-trait",
+ "k256",
+ "rand",
+ "thiserror 2.0.6",
+]
+
+[[package]]
 name = "alloy-signer-trezor"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b754988ef4e1f5f7d55c132949bb2a10491ed6bbf1d35108269014f50da1823f"
 dependencies = [
- "alloy-consensus",
- "alloy-network",
+ "alloy-consensus 0.5.4",
+ "alloy-network 0.5.4",
  "alloy-primitives",
- "alloy-signer",
+ "alloy-signer 0.5.4",
  "async-trait",
  "semver 1.0.23",
  "thiserror 1.0.69",
@@ -602,7 +954,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap",
+ "indexmap 2.7.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -657,7 +1009,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be77579633ebbc1266ae6fd7694f75c408beb1aeb6865d0b18f22893c265a061"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.5.4",
  "base64 0.22.1",
  "futures-util",
  "futures-utils-wasm",
@@ -668,7 +1020,27 @@ dependencies = [
  "tower 0.5.1",
  "tracing",
  "url",
- "wasmtimer",
+ "wasmtimer 0.2.1",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17722a198f33bbd25337660787aea8b8f57814febb7c746bc30407bdfc39448"
+dependencies = [
+ "alloy-json-rpc 0.9.2",
+ "base64 0.22.1",
+ "futures-util",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.6",
+ "tokio",
+ "tower 0.5.1",
+ "tracing",
+ "url",
+ "wasmtimer 0.4.1",
 ]
 
 [[package]]
@@ -677,8 +1049,23 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91fd1a5d0827939847983b46f2f79510361f901dc82f8e3c38ac7397af142c6e"
 dependencies = [
- "alloy-json-rpc",
- "alloy-transport",
+ "alloy-json-rpc 0.5.4",
+ "alloy-transport 0.5.4",
+ "reqwest 0.12.9",
+ "serde_json",
+ "tower 0.5.1",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1509599021330a31c4a6816b655e34bf67acb1cc03c564e09fd8754ff6c5de"
+dependencies = [
+ "alloy-json-rpc 0.9.2",
+ "alloy-transport 0.9.2",
  "reqwest 0.12.9",
  "serde_json",
  "tower 0.5.1",
@@ -692,13 +1079,13 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8073d1186bfeeb8fbdd1292b6f1a0731f3aed8e21e1463905abfae0b96a887a6"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 0.5.4",
  "alloy-pubsub",
- "alloy-transport",
+ "alloy-transport 0.5.4",
  "bytes",
  "futures 0.3.31",
  "interprocess",
- "pin-project",
+ "pin-project 1.1.7",
  "serde_json",
  "tokio",
  "tokio-util",
@@ -712,7 +1099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61f27837bb4a1d6c83a28231c94493e814882f0e9058648a97e908a5f3fc9fcf"
 dependencies = [
  "alloy-pubsub",
- "alloy-transport",
+ "alloy-transport 0.5.4",
  "futures 0.3.31",
  "http 1.2.0",
  "rustls 0.23.19",
@@ -721,6 +1108,22 @@ dependencies = [
  "tokio-tungstenite 0.24.0",
  "tracing",
  "ws_stream_wasm",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6917c79e837aa7b77b7a6dae9f89cbe15313ac161c4d3cfaf8909ef21f3d22d8"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "arrayvec",
+ "derive_more",
+ "nybbles",
+ "serde",
+ "smallvec",
+ "tracing",
 ]
 
 [[package]]
@@ -946,6 +1349,9 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ascii-canvas"
@@ -954,6 +1360,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
 dependencies = [
  "term",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1243,6 +1662,53 @@ dependencies = [
  "aws-smithy-types",
  "rustc_version 0.4.1",
  "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 1.0.2",
+ "tower 0.5.1",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 1.0.2",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -2423,7 +2889,7 @@ dependencies = [
  "instant",
  "jsonwebtoken 8.3.0",
  "once_cell",
- "pin-project",
+ "pin-project 1.1.7",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -2551,7 +3017,7 @@ version = "0.2.0"
 source = "git+https://github.com/foundry-rs/foundry?rev=57bb12e#57bb12e022fb9ea46a4a7ca8647eb016e8d43ca3"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.5.4",
  "eyre",
  "foundry-common",
  "foundry-compilers",
@@ -2595,16 +3061,16 @@ name = "foundry-cheatcodes"
 version = "0.2.0"
 source = "git+https://github.com/foundry-rs/foundry?rev=57bb12e#57bb12e022fb9ea46a4a7ca8647eb016e8d43ca3"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.5.4",
  "alloy-dyn-abi",
- "alloy-genesis",
+ "alloy-genesis 0.5.4",
  "alloy-json-abi",
  "alloy-primitives",
- "alloy-provider",
+ "alloy-provider 0.5.4",
  "alloy-rlp",
- "alloy-rpc-types",
- "alloy-signer",
- "alloy-signer-local",
+ "alloy-rpc-types 0.5.4",
+ "alloy-signer 0.5.4",
+ "alloy-signer-local 0.5.4",
  "alloy-sol-types",
  "base64 0.22.1",
  "chrono",
@@ -2653,20 +3119,20 @@ name = "foundry-common"
 version = "0.2.0"
 source = "git+https://github.com/foundry-rs/foundry?rev=57bb12e#57bb12e022fb9ea46a4a7ca8647eb016e8d43ca3"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.5.4",
  "alloy-contract",
  "alloy-dyn-abi",
  "alloy-json-abi",
- "alloy-json-rpc",
+ "alloy-json-rpc 0.5.4",
  "alloy-primitives",
- "alloy-provider",
+ "alloy-provider 0.5.4",
  "alloy-pubsub",
- "alloy-rpc-client",
- "alloy-rpc-types",
- "alloy-serde",
+ "alloy-rpc-client 0.5.4",
+ "alloy-rpc-types 0.5.4",
+ "alloy-serde 0.5.4",
  "alloy-sol-types",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 0.5.4",
+ "alloy-transport-http 0.5.4",
  "alloy-transport-ipc",
  "alloy-transport-ws",
  "anstream",
@@ -2700,12 +3166,12 @@ name = "foundry-common-fmt"
 version = "0.2.0"
 source = "git+https://github.com/foundry-rs/foundry?rev=57bb12e#57bb12e022fb9ea46a4a7ca8647eb016e8d43ca3"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.5.4",
  "alloy-dyn-abi",
- "alloy-network",
+ "alloy-network 0.5.4",
  "alloy-primitives",
- "alloy-rpc-types",
- "alloy-serde",
+ "alloy-rpc-types 0.5.4",
+ "alloy-serde 0.5.4",
  "chrono",
  "comfy-table",
  "revm-primitives",
@@ -2901,14 +3367,14 @@ version = "0.2.0"
 source = "git+https://github.com/foundry-rs/foundry?rev=57bb12e#57bb12e022fb9ea46a4a7ca8647eb016e8d43ca3"
 dependencies = [
  "alloy-dyn-abi",
- "alloy-genesis",
+ "alloy-genesis 0.5.4",
  "alloy-json-abi",
  "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types",
- "alloy-serde",
+ "alloy-provider 0.5.4",
+ "alloy-rpc-types 0.5.4",
+ "alloy-serde 0.5.4",
  "alloy-sol-types",
- "alloy-transport",
+ "alloy-transport 0.5.4",
  "auto_impl",
  "eyre",
  "foundry-cheatcodes-spec",
@@ -2960,7 +3426,7 @@ dependencies = [
  "foundry-evm-core",
  "foundry-evm-coverage",
  "foundry-evm-traces",
- "indexmap",
+ "indexmap 2.7.0",
  "itertools 0.13.0",
  "parking_lot",
  "proptest",
@@ -3006,10 +3472,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fe4a1e7e0f122b28afc156681687249bd5cf910d9bf873efb1181e4d41fbc3"
 dependencies = [
  "alloy-primitives",
- "alloy-provider",
- "alloy-rpc-types",
- "alloy-serde",
- "alloy-transport",
+ "alloy-provider 0.5.4",
+ "alloy-rpc-types 0.5.4",
+ "alloy-serde 0.5.4",
+ "alloy-transport 0.5.4",
  "eyre",
  "futures 0.3.31",
  "parking_lot",
@@ -3049,13 +3515,13 @@ name = "foundry-wallets"
 version = "0.2.0"
 source = "git+https://github.com/foundry-rs/foundry?rev=57bb12e#57bb12e022fb9ea46a4a7ca8647eb016e8d43ca3"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.5.4",
  "alloy-dyn-abi",
- "alloy-network",
+ "alloy-network 0.5.4",
  "alloy-primitives",
- "alloy-signer",
- "alloy-signer-ledger",
- "alloy-signer-local",
+ "alloy-signer 0.5.4",
+ "alloy-signer-ledger 0.5.4",
+ "alloy-signer-local 0.5.4",
  "alloy-signer-trezor",
  "alloy-sol-types",
  "async-trait",
@@ -3215,6 +3681,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "gcloud-sdk"
+version = "0.25.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0775bfa745cdf7287ae9765a685a813b91049b6b6d5ca3de20a3d5d16a80d8b2"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures 0.3.31",
+ "hyper 1.5.1",
+ "jsonwebtoken 9.3.0",
+ "once_cell",
+ "prost",
+ "prost-types",
+ "reqwest 0.12.9",
+ "secret-vault-value",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tonic",
+ "tower 0.5.1",
+ "tower-layer",
+ "tower-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3298,7 +3792,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.7.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3317,12 +3811,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.2.0",
- "indexmap",
+ "indexmap 2.7.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -3531,6 +4031,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -3571,6 +4072,19 @@ dependencies = [
  "tokio-rustls 0.26.1",
  "tower-service",
  "webpki-roots 0.26.7",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.5.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -3819,6 +4333,16 @@ name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
 
 [[package]]
 name = "indexmap"
@@ -4181,6 +4705,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4230,6 +4760,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "mini-moka"
@@ -4464,6 +5004,19 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "nybbles"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983bb634df7248924ee0c4c3a749609b5abcb082c28fffe3254b3eb3602b307"
+dependencies = [
+ "alloy-rlp",
+ "const-hex",
+ "proptest",
+ "serde",
+ "smallvec",
+]
 
 [[package]]
 name = "object"
@@ -4728,7 +5281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.7.0",
 ]
 
 [[package]]
@@ -4794,11 +5347,31 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
+dependencies = [
+ "pin-project-internal 0.4.30",
+]
+
+[[package]]
+name = "pin-project"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 1.1.7",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5032,6 +5605,38 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -5420,6 +6025,7 @@ version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
@@ -5438,6 +6044,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
@@ -5456,10 +6063,12 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls 0.26.1",
  "tokio-socks",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 0.26.7",
  "windows-registry",
@@ -5490,7 +6099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e29c662f7887f3b659d4b0fd234673419a8fcbeaa1ecc29bf7034c0a75cc8ea"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 0.5.4",
  "alloy-rpc-types-trace",
  "alloy-sol-types",
  "anstyle",
@@ -5538,7 +6147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d11fa1e195b0bebaf3fb18596f314a13ba3a4cb1fdd16d3465934d812fd921e"
 dependencies = [
  "alloy-eip2930",
- "alloy-eip7702",
+ "alloy-eip7702 0.3.2",
  "alloy-primitives",
  "auto_impl",
  "bitflags 2.6.0",
@@ -5784,6 +6393,7 @@ version = "0.23.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
 dependencies = [
+ "log",
  "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
@@ -6012,6 +6622,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "secret-vault-value"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc32a777b53b3433b974c9c26b6d502a50037f8da94e46cb8ce2ced2cfdfaea0"
+dependencies = [
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6112,7 +6735,7 @@ version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
- "indexmap",
+ "indexmap 2.7.0",
  "itoa",
  "memchr",
  "ryu",
@@ -6317,6 +6940,9 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -6923,7 +7549,7 @@ version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
- "indexmap",
+ "indexmap 2.7.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -6945,11 +7571,44 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap",
+ "indexmap 2.7.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.7",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.5.1",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project 1.1.7",
+ "prost",
+ "rustls-native-certs 0.8.1",
+ "rustls-pemfile 2.2.0",
+ "socket2",
+ "tokio",
+ "tokio-rustls 0.26.1",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6958,6 +7617,15 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project 1.1.7",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6988,6 +7656,18 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tower-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project 0.4.30",
+ "tower-service",
+]
 
 [[package]]
 name = "tracing"
@@ -7040,7 +7720,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project",
+ "pin-project 1.1.7",
  "tracing",
 ]
 
@@ -7189,10 +7869,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tycho-execution"
+version = "0.32.0"
+source = "git+https://github.com/propeller-heads/tycho-execution.git?rev=58749bd65b697673aff94f75954dff5504182041#58749bd65b697673aff94f75954dff5504182041"
+dependencies = [
+ "alloy 0.9.2",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "chrono",
+ "dotenv",
+ "hex",
+ "lazy_static",
+ "num-bigint",
+ "num-traits",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tycho-core",
+]
+
+[[package]]
 name = "tycho-simulation"
 version = "0.77.2"
 dependencies = [
- "alloy",
+ "alloy 0.5.4",
  "alloy-primitives",
  "alloy-sol-types",
  "anyhow",
@@ -7229,6 +7930,7 @@ dependencies = [
  "tracing-subscriber",
  "tycho-client",
  "tycho-core",
+ "tycho-execution",
  "unicode-width 0.1.14",
  "uuid 1.11.0",
 ]
@@ -7408,7 +8110,7 @@ version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
 dependencies = [
- "indexmap",
+ "indexmap 2.7.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -7597,10 +8299,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmtimer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7ed9d8b15c7fb594d72bfb4b5a276f3d2029333cd93a932f376f5937f6f80ee"
+dependencies = [
+ "futures 0.3.31",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0048ad49a55b9deb3953841fa1fc5858f0efbcb7a18868c899a360269fac1b23"
 dependencies = [
  "futures 0.3.31",
  "js-sys",
@@ -8056,7 +8785,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap",
+ "indexmap 2.7.0",
  "memchr",
  "thiserror 2.0.6",
  "zopfli",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7872,7 +7872,7 @@ dependencies = [
 [[package]]
 name = "tycho-execution"
 version = "0.51.0"
-source = "git+https://github.com/propeller-heads/tycho-execution.git?tag=0.51.0#dd6b1151b241adb37b4a4cc0673ade068f937de1"
+source = "git+https://github.com/propeller-heads/tycho-execution.git?rev=5aec1c08117c249ebe68421367ad6a68636fca9b#5aec1c08117c249ebe68421367ad6a68636fca9b"
 dependencies = [
  "alloy 0.9.2",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7870,8 +7870,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.32.0"
-source = "git+https://github.com/propeller-heads/tycho-execution.git?rev=58749bd65b697673aff94f75954dff5504182041#58749bd65b697673aff94f75954dff5504182041"
+version = "0.33.0"
+source = "git+https://github.com/propeller-heads/tycho-execution.git?rev=1e2c628ba969594709912157b0b8df816684b95d#1e2c628ba969594709912157b0b8df816684b95d"
 dependencies = [
  "alloy 0.9.2",
  "alloy-primitives",
@@ -7882,6 +7882,7 @@ dependencies = [
  "lazy_static",
  "num-bigint",
  "num-traits",
+ "once_cell",
  "serde",
  "serde_json",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7874,8 +7874,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.53.0"
-source = "git+https://github.com/propeller-heads/tycho-execution.git?rev=05a1843f9c3f916d4af8fbf67cccf3b3b94aeab8#05a1843f9c3f916d4af8fbf67cccf3b3b94aeab8"
+version = "0.54.0"
+source = "git+https://github.com/propeller-heads/tycho-execution.git?tag=0.54.0#87e7394b0aca9781c44782eeb117508c7dddf9e2"
 dependencies = [
  "alloy 0.9.2",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,10 @@ dependencies = [
  "alloy-network 0.5.4",
  "alloy-provider 0.5.4",
  "alloy-rpc-client 0.5.4",
+ "alloy-rpc-types 0.5.4",
  "alloy-serde 0.5.4",
+ "alloy-signer 0.5.4",
+ "alloy-signer-local 0.5.4",
  "alloy-transport 0.5.4",
  "alloy-transport-http 0.5.4",
 ]
@@ -5625,7 +5628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.90",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4891,6 +4891,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -7870,13 +7871,14 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.33.0"
-source = "git+https://github.com/propeller-heads/tycho-execution.git?rev=1e2c628ba969594709912157b0b8df816684b95d#1e2c628ba969594709912157b0b8df816684b95d"
+version = "0.46.0"
+source = "git+https://github.com/propeller-heads/tycho-execution.git?rev=8a10bdcf9d2c9cc7f00fc72d8fa6f294e01753c7#8a10bdcf9d2c9cc7f00fc72d8fa6f294e01753c7"
 dependencies = [
  "alloy 0.9.2",
  "alloy-primitives",
  "alloy-sol-types",
  "chrono",
+ "clap",
  "dotenv",
  "hex",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7871,8 +7871,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.46.0"
-source = "git+https://github.com/propeller-heads/tycho-execution.git?rev=8a10bdcf9d2c9cc7f00fc72d8fa6f294e01753c7#8a10bdcf9d2c9cc7f00fc72d8fa6f294e01753c7"
+version = "0.51.0"
+source = "git+https://github.com/propeller-heads/tycho-execution.git?tag=0.51.0#dd6b1151b241adb37b4a4cc0673ade068f937de1"
 dependencies = [
  "alloy 0.9.2",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ lazy_static = "1.4.0"
 # Tycho dependencies
 tycho-core = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-core", tag = "0.56.5" }
 tycho-client = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-client", tag = "0.56.5" }
-tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution.git", package = "tycho-execution", rev = "58749bd65b697673aff94f75954dff5504182041", features = ["evm"] }
+tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution.git", package = "tycho-execution", rev = "1e2c628ba969594709912157b0b8df816684b95d", features = ["evm"] }
 
 # EVM dependencies
 foundry-config = { git = "https://github.com/foundry-rs/foundry", rev = "57bb12e", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ lazy_static = "1.4.0"
 # Tycho dependencies
 tycho-core = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-core", tag = "0.56.5" }
 tycho-client = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-client", tag = "0.56.5" }
+tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution.git", package = "tycho-execution", rev = "58749bd65b697673aff94f75954dff5504182041", features = ["evm"] }
 
 # EVM dependencies
 foundry-config = { git = "https://github.com/foundry-rs/foundry", rev = "57bb12e", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ alloy-primitives = { version = "0.8.9", features = [
     "map-foldhash",
 ] }
 alloy-sol-types = { version = "0.8.14" }
-alloy = { version = "0.5.4", features = ["providers"] }
+alloy = { version = "0.5.4", features = ["providers", "signer-local", "rpc-types-eth"] }
 revm = { version = "17.1.0", features = ["ethersdb", "serde"], optional = true }
 revm-inspectors = { version = "0.10", features = ["serde"], optional = true }
 num-bigint = "0.4.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ lazy_static = "1.4.0"
 # Tycho dependencies
 tycho-core = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-core", tag = "0.56.5" }
 tycho-client = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-client", tag = "0.56.5" }
-tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution.git", package = "tycho-execution", features = ["evm"], rev = "05a1843f9c3f916d4af8fbf67cccf3b3b94aeab8" }
+tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution.git", package = "tycho-execution", features = ["evm"], tag = "0.54.0" }
 
 # EVM dependencies
 foundry-config = { git = "https://github.com/foundry-rs/foundry", rev = "57bb12e", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ lazy_static = "1.4.0"
 # Tycho dependencies
 tycho-core = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-core", tag = "0.56.5" }
 tycho-client = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-client", tag = "0.56.5" }
-tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution.git", package = "tycho-execution", features = ["evm"], tag = "0.51.0" }
+tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution.git", package = "tycho-execution", features = ["evm"], rev = "5aec1c08117c249ebe68421367ad6a68636fca9b" }
 
 # EVM dependencies
 foundry-config = { git = "https://github.com/foundry-rs/foundry", rev = "57bb12e", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ lazy_static = "1.4.0"
 # Tycho dependencies
 tycho-core = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-core", tag = "0.56.5" }
 tycho-client = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-client", tag = "0.56.5" }
-tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution.git", package = "tycho-execution", features = ["evm"], rev = "5aec1c08117c249ebe68421367ad6a68636fca9b" }
+tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution.git", package = "tycho-execution", features = ["evm"], rev = "05a1843f9c3f916d4af8fbf67cccf3b3b94aeab8" }
 
 # EVM dependencies
 foundry-config = { git = "https://github.com/foundry-rs/foundry", rev = "57bb12e", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ lazy_static = "1.4.0"
 # Tycho dependencies
 tycho-core = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-core", tag = "0.56.5" }
 tycho-client = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-client", tag = "0.56.5" }
-tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution.git", package = "tycho-execution", rev = "1e2c628ba969594709912157b0b8df816684b95d", features = ["evm"] }
+tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution.git", package = "tycho-execution", rev = "8a10bdcf9d2c9cc7f00fc72d8fa6f294e01753c7", features = ["evm"] }
 
 # EVM dependencies
 foundry-config = { git = "https://github.com/foundry-rs/foundry", rev = "57bb12e", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ lazy_static = "1.4.0"
 # Tycho dependencies
 tycho-core = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-core", tag = "0.56.5" }
 tycho-client = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-client", tag = "0.56.5" }
-tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution.git", package = "tycho-execution", rev = "8a10bdcf9d2c9cc7f00fc72d8fa6f294e01753c7", features = ["evm"] }
+tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution.git", package = "tycho-execution", features = ["evm"], tag = "0.51.0" }
 
 # EVM dependencies
 foundry-config = { git = "https://github.com/foundry-rs/foundry", rev = "57bb12e", optional = true }

--- a/examples/price_printer/Readme.md
+++ b/examples/price_printer/Readme.md
@@ -6,6 +6,6 @@ quotes from each pool.
 ## How to run
 
 ```bash
-export RPC_URL=<your-node-rpc-url>
+export ETH_RPC_URL=<your-node-rpc-url>
 cargo run --release --example price_printer -- --tvl-threshold 1000 --chain <ethereum | base>
 ```

--- a/examples/quickstart/Readme.md
+++ b/examples/quickstart/Readme.md
@@ -8,14 +8,14 @@ This quickstart guide enables you to:
 ## How to run
 
 ```bash
-export RPC_URL=<your-eth-rpc-url>
+export ETH_RPC_URL=<your-eth-rpc-url>
 cargo run --release --example quickstart
 ```
 
 By default, the example will trade 1 WETH -> USDC. If you want a different trade you can do:
 
 ```bash
-cargo run --release --example quickstart -- --sell-token "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" --buy-token "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" --sell-amount 10000
+cargo run --release --example quickstart -- --sell-token "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" --buy-token "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" --sell-amount 10
 ```
 
 for 10000 USDC -> WBTC.

--- a/examples/quickstart/Readme.md
+++ b/examples/quickstart/Readme.md
@@ -3,9 +3,7 @@
 This quickstart guide enables you to:
 
 1. Retrieve data from the Tycho Indexer.
-2. Leverage Tycho Simulation to:
-    1. Calculate spot prices.
-    2. Simulate token swaps.
+2. Leverage Tycho Simulation to get the best amount out of a trade.
 
 ## How to run
 
@@ -13,6 +11,14 @@ This quickstart guide enables you to:
 export RPC_URL=<your-eth-rpc-url>
 cargo run --release --example quickstart
 ```
+
+By default, the example will trade 1 WETH -> USDC. If you want a different trade you can do:
+
+```bash
+cargo run --release --example quickstart -- --sell-token "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" --buy-token "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599" --sell-amount 10000
+```
+
+for 10000 USDC -> WBTC.
 
 See [here](https://docs.propellerheads.xyz/tycho/for-solvers/tycho-quickstart) a complete guide on how to run the
 Quickstart example.

--- a/examples/quickstart/Readme.md
+++ b/examples/quickstart/Readme.md
@@ -20,5 +20,11 @@ cargo run --release --example quickstart -- --sell-token "0xA0b86991c6218b36c1d1
 
 for 10000 USDC -> WBTC.
 
+To be able to execute or simulate the best swap, you need to pass your private key:
+
+```bash
+cargo run --release --example quickstart -- --swapper-pk <your-private-key>
+```
+
 See [here](https://docs.propellerheads.xyz/tycho/for-solvers/tycho-quickstart) a complete guide on how to run the
 Quickstart example.

--- a/examples/quickstart/main.rs
+++ b/examples/quickstart/main.rs
@@ -1,8 +1,14 @@
-use std::{collections::HashMap, env};
+use std::{
+    collections::{HashMap, HashSet},
+    env,
+    str::FromStr,
+};
 
+use clap::Parser;
 use futures::StreamExt;
 use num_bigint::BigUint;
 use tracing_subscriber::EnvFilter;
+use tycho_core::Bytes;
 use tycho_simulation::{
     evm::{
         engine_db::tycho_db::PreCachedDB,
@@ -21,6 +27,19 @@ use tycho_simulation::{
     utils::load_all_tokens,
 };
 
+#[derive(Parser)]
+struct Cli {
+    #[arg(short, long, default_value = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")]
+    sell_token: String,
+    #[arg(short, long, default_value = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")]
+    buy_token: String,
+    #[arg(short, long, default_value_t = 1)]
+    sell_amount: u32,
+    /// The tvl threshold to filter the graph by
+    #[arg(short, long, default_value_t = 100.0)]
+    tvl_threshold: f64,
+}
+
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt()
@@ -33,8 +52,8 @@ async fn main() {
     let tycho_api_key: String =
         env::var("TYCHO_API_KEY").unwrap_or_else(|_| "sampletoken".to_string());
 
-    let tvl_threshold = 10_000.0;
-    let tvl_filter = ComponentFilter::with_tvl_range(tvl_threshold, tvl_threshold);
+    let cli = Cli::parse();
+    let tvl_filter = ComponentFilter::with_tvl_range(cli.tvl_threshold, cli.tvl_threshold);
 
     let all_tokens = load_all_tokens(
         tycho_url.as_str(),
@@ -45,7 +64,27 @@ async fn main() {
         None,
     )
     .await;
+
+    let sell_token_address =
+        Bytes::from_str(&cli.sell_token).expect("Invalid address for sell token");
+    let buy_token_address = Bytes::from_str(&cli.buy_token).expect("Invalid address for buy token");
+    let sell_token = all_tokens
+        .get(&sell_token_address)
+        .expect("Sell token not found")
+        .clone();
+    let buy_token = all_tokens
+        .get(&buy_token_address)
+        .expect("Buy token not found")
+        .clone();
+    let amount_in =
+        BigUint::from(cli.sell_amount) * BigUint::from(10u32).pow(sell_token.decimals as u32);
+
+    println!(
+        "Looking for the best swap for {} {} -> {}",
+        cli.sell_amount, sell_token.symbol, buy_token.symbol
+    );
     let mut pairs: HashMap<String, Vec<Token>> = HashMap::new();
+    let mut amounts_out: HashMap<String, BigUint> = HashMap::new();
 
     let mut protocol_stream = ProtocolStreamBuilder::new(&tycho_url, Chain::Ethereum)
         .exchange::<UniswapV2State>("uniswap_v2", tvl_filter.clone(), None)
@@ -69,11 +108,25 @@ async fn main() {
 
     while let Some(message) = protocol_stream.next().await {
         let message = message.expect("Could not receive message");
-        print_calculations(message, &mut pairs);
+        get_best_swap(
+            message,
+            &mut pairs,
+            amount_in.clone(),
+            sell_token.clone(),
+            buy_token.clone(),
+            &mut amounts_out,
+        );
     }
 }
 
-fn print_calculations(message: BlockUpdate, pairs: &mut HashMap<String, Vec<Token>>) {
+fn get_best_swap(
+    message: BlockUpdate,
+    pairs: &mut HashMap<String, Vec<Token>>,
+    amount_in: BigUint,
+    sell_token: Token,
+    buy_token: Token,
+    amounts_out: &mut HashMap<String, BigUint>,
+) {
     println!("==================== Received block {:?} ====================", message.block_number);
     for (id, comp) in message.new_pairs.iter() {
         pairs
@@ -81,31 +134,44 @@ fn print_calculations(message: BlockUpdate, pairs: &mut HashMap<String, Vec<Toke
             .or_insert_with(|| comp.tokens.clone());
     }
     if message.states.is_empty() {
-        println!("No pools were updated this block");
+        println!("No pools of interest were updated this block. The best swap is the previous one");
         return
     }
-    println!("Using only pools that were updated this block...");
-    for (id, state) in message.states.iter().take(10) {
+    for (id, state) in message.states.iter() {
         if let Some(tokens) = pairs.get(id) {
-            let formatted_token_str = format!("{:}/{:}", &tokens[0].symbol, &tokens[1].symbol);
-            println!("Calculations for pool {:?} with tokens {:?}", id, formatted_token_str);
-            state
-                .spot_price(&tokens[0], &tokens[1])
-                .map(|price| println!("Spot price {:?}: {:?}", formatted_token_str, price))
-                .map_err(|e| eprintln!("Error calculating spot price for Pool {:?}: {:?}", id, e))
-                .ok();
-            let amount_in =
-                BigUint::from(1u32) * BigUint::from(10u32).pow(tokens[0].decimals as u32);
-            state
-                .get_amount_out(amount_in, &tokens[0], &tokens[1])
-                .map(|result| {
-                    println!(
-                        "Amount out for trading 1 {:?} -> {:?}: {:?} (takes {:?} gas)",
-                        &tokens[0].symbol, &tokens[1].symbol, result.amount, result.gas
-                    )
-                })
-                .map_err(|e| eprintln!("Error calculating amount out for Pool {:?}: {:?}", id, e))
-                .ok();
+            if HashSet::from([&sell_token, &buy_token]) == HashSet::from([&tokens[0], &tokens[1]]) {
+                let amount_out = state
+                    .get_amount_out(amount_in.clone(), &sell_token, &buy_token)
+                    .map_err(|e| {
+                        eprintln!("Error calculating amount out for Pool {:?}: {:?}", id, e)
+                    })
+                    .ok();
+                if let Some(amount_out) = amount_out {
+                    amounts_out.insert(id.clone(), amount_out.amount);
+                }
+                // If you would like to save spot prices instead of the amount out, do
+                // let spot_price = state
+                //     .spot_price(&tokens[0], &tokens[1])
+                //     .ok();
+            }
         }
+    }
+    encode_best_amount_out(amounts_out);
+}
+
+fn encode_best_amount_out(amounts_out: &HashMap<String, BigUint>) {
+    if let Some((key, amount_out)) = amounts_out
+        .iter()
+        .max_by_key(|(_, value)| value.to_owned())
+    {
+        println!(
+            "Pool with the highest amount out: {} with {} (out of {} results)",
+            key,
+            amount_out,
+            amounts_out.len()
+        );
+        // TODO: encode using tycho-execution
+    } else {
+        println!("There aren't pools with the tokens we are looking for");
     }
 }

--- a/examples/quickstart/main.rs
+++ b/examples/quickstart/main.rs
@@ -239,7 +239,7 @@ fn encode(
         exact_out: false,     // it's an exact in solution
         checked_amount: None, // the amount out will not be checked in execution
         swaps: vec![simple_swap],
-        router_address: Bytes::from_str("0x1234567890abcdef1234567890abcdef12345678")
+        router_address: Bytes::from_str("0xFfA5ec2e444e4285108e4a17b82dA495c178427B")
             .expect("Failed to create router address"),
         ..Default::default()
     };

--- a/examples/quickstart/main.rs
+++ b/examples/quickstart/main.rs
@@ -128,7 +128,7 @@ async fn main() {
     let strategy_encoder_registry =
         EVMStrategyEncoderRegistry::new(Chain::Ethereum, None, signer_pk.clone())
             .expect("Failed to create strategy encoder registry");
-    let encoder = EVMTychoEncoder::new(strategy_encoder_registry, router_address)
+    let encoder = EVMTychoEncoder::new(strategy_encoder_registry, router_address, Chain::Ethereum)
         .expect("Failed to create encoder");
 
     while let Some(message) = protocol_stream.next().await {

--- a/examples/quickstart/main.rs
+++ b/examples/quickstart/main.rs
@@ -65,7 +65,7 @@ struct Cli {
     #[arg(short, long, default_value_t = 1.0)]
     sell_amount: f64,
     /// The tvl threshold to filter the graph by
-    #[arg(short, long, default_value_t = 10.0)]
+    #[arg(short, long, default_value_t = 100.0)]
     tvl_threshold: f64,
     #[arg(short, long, default_value = FAKE_PK)]
     swapper_pk: String,
@@ -192,7 +192,7 @@ async fn main() {
                 continue
             }
             println!("Do you want to simulate, execute or skip this swap?");
-            println!("Please be aware that the market might move while you make your decision. Which might lead to a revert if you've set a min amount out or slippage.");
+            println!("Please be aware that the market might move while you make your decision, which might lead to a revert if you've set a min amount out or slippage.");
             print!("(simulate/execute/skip): ");
             io::stdout().flush().unwrap();
             let mut input = String::new();

--- a/examples/quickstart/main.rs
+++ b/examples/quickstart/main.rs
@@ -15,7 +15,7 @@ use alloy::{
     },
     rpc::types::{
         simulate::{SimBlock, SimulatePayload},
-        TransactionInput, TransactionReceipt, TransactionRequest,
+        TransactionInput, TransactionRequest,
     },
     signers::local::PrivateKeySigner,
     transports::http::{Client, Http},
@@ -190,7 +190,9 @@ async fn main() {
                 user_address.clone(),
             );
 
-            print!("Do you want to simulate, execute or skip this swap? (simulate/execute/skip): ");
+            println!("Do you want to simulate, execute or skip this swap?");
+            println!("Please be aware that the market might move while you make your decision.");
+            println!("(simulate/execute/skip): ");
             io::stdout().flush().unwrap();
             let mut input = String::new();
             io::stdin()
@@ -386,12 +388,10 @@ fn encode(
     };
 
     // Encode the solution
-    let tx = encoder
+    encoder
         .encode_router_calldata(vec![solution.clone()])
         .expect("Failed to encode router calldata")[0]
-        .clone();
-
-    return tx;
+        .clone()
 }
 
 async fn get_tx_requests(
@@ -427,15 +427,15 @@ async fn get_tx_requests(
     );
     let data = encode_input(approve_function_signature, args.abi_encode());
     let nonce = provider
-        .get_transaction_count(user_address.clone())
+        .get_transaction_count(user_address)
         .await
         .expect("Failed to get nonce");
 
     let approval_request = TransactionRequest::default()
-        .from(user_address.clone())
+        .from(user_address)
         .to(sell_token_address)
         .input(TransactionInput { input: Some(AlloyBytes::from(data)), data: None })
-        .gas_limit(50_000u64.into())
+        .gas_limit(50_000u64)
         .max_fee_per_gas(max_fee_per_gas.into())
         .max_priority_fee_per_gas(max_priority_fee_per_gas.into())
         .nonce(nonce);
@@ -447,7 +447,7 @@ async fn get_tx_requests(
         .input(TransactionInput { input: Some(AlloyBytes::from(tx.data)), data: None })
         .max_fee_per_gas(max_fee_per_gas.into())
         .max_priority_fee_per_gas(max_priority_fee_per_gas.into())
-        .gas_limit(300_000u64.into())
+        .gas_limit(300_000u64)
         .nonce(nonce + 1);
 
     (approval_request, swap_request)

--- a/examples/quickstart/main.rs
+++ b/examples/quickstart/main.rs
@@ -54,6 +54,8 @@ use tycho_simulation::{
     utils::load_all_tokens,
 };
 
+const FAKE_PK: &str = "0x123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234";
+
 #[derive(Parser)]
 struct Cli {
     #[arg(short, long, default_value = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")]
@@ -65,7 +67,7 @@ struct Cli {
     /// The tvl threshold to filter the graph by
     #[arg(short, long, default_value_t = 10.0)]
     tvl_threshold: f64,
-    #[arg(short, long)]
+    #[arg(short, long, default_value = FAKE_PK)]
     swapper_pk: String,
 }
 
@@ -185,6 +187,10 @@ async fn main() {
                 Bytes::from(wallet.address().to_vec()),
             );
 
+            if cli.swapper_pk == FAKE_PK {
+                println!("Signer private key was not provided. Skipping simulation/execution...");
+                continue
+            }
             println!("Do you want to simulate, execute or skip this swap?");
             println!("Please be aware that the market might move while you make your decision. Which might lead to a revert if you've set a min amount out or slippage.");
             print!("(simulate/execute/skip): ");

--- a/src/protocol/models.rs
+++ b/src/protocol/models.rs
@@ -103,9 +103,9 @@ impl ProtocolComponent {
     }
 }
 
-impl From<ProtocolComponent> for tycho_core::dto::ProtocolComponent {
+impl From<ProtocolComponent> for tycho_core::models::protocol::ProtocolComponent {
     fn from(component: ProtocolComponent) -> Self {
-        tycho_core::dto::ProtocolComponent {
+        tycho_core::models::protocol::ProtocolComponent {
             id: hex::encode(component.id),
             protocol_system: component.protocol_system,
             protocol_type_name: component.protocol_type_name,
@@ -115,11 +115,11 @@ impl From<ProtocolComponent> for tycho_core::dto::ProtocolComponent {
                 .into_iter()
                 .map(|t| t.address)
                 .collect(),
-            contract_ids: component.contract_ids,
             static_attributes: component.static_attributes,
             change: Default::default(),
             creation_tx: component.creation_tx,
             created_at: component.created_at,
+            contract_addresses: component.contract_ids,
         }
     }
 }

--- a/src/protocol/models.rs
+++ b/src/protocol/models.rs
@@ -109,7 +109,7 @@ impl From<ProtocolComponent> for tycho_core::models::protocol::ProtocolComponent
             id: hex::encode(component.id),
             protocol_system: component.protocol_system,
             protocol_type_name: component.protocol_type_name,
-            chain: component.chain.into(),
+            chain: component.chain,
             tokens: component
                 .tokens
                 .into_iter()


### PR DESCRIPTION
Refactor: Instead of looping through the top 10 pools and calculating spot prices and amount out for each block, it will return the best amount out for a token pair. The trade tokens can be defined through CLI parameters. 

Add execution to quickstart. The user can choose to simulate, execute or skip the swap. The output looks like this
````
Looking for the best swap for 1 WETH -> USDC
==================== Received block 21937897 ====================
The best swap (out of 6 possible pools) is:
protocol: "uniswap_v3"
id: "0x88e6a0c2ddd26feeb64f039a2c41296fcb3f5640"
swap: 1000000000000000000 WETH -> 2351701017 USDC
Do you want to simulate, execute or skip this swap?
Please be aware that the market might move while you make your decision. Which might lead to a revert if you've set a min amount out or slippage.
(simulate/execute/skip): 
````
if they choose `simulate`
````
(simulate/execute/skip): simulate
Simulating by performing an approval (for permit2) and a swap transaction...
Simulated Block 21937944:
  Transaction 1: Status: true, Gas Used: 45992
  Transaction 2: Status: false, Gas Used: 66574
````
if they choose `execute`
````
(simulate/execute/skip): execute
Executing by performing an approval (for permit2) and a swap transaction...
Approval transaction sent with hash: 0x267fc0027c861bd740d9752fde2d3b44c6db148c3da7c4fbab082feeb484bb89 and status: true
Swap transaction sent with hash: 0x330458ba7805a9647fa08f3bf4c7634f8975f1ea7d2b3e3e135916ddbcc90926 and status: true
````