### PR TITLE
feat: Extend ProtocolComponent to have the attributes of the core model

### DIFF
--- a/examples/price_printer/ui.rs
+++ b/examples/price_printer/ui.rs
@@ -140,7 +140,7 @@ impl App {
 
     pub fn update_data(&mut self, update: BlockUpdate) {
         for (id, comp) in update.new_pairs.iter() {
-            let name = format!("{:#042x}", comp.address);
+            let name = format!("{:#042x}", comp.id);
             let tokens = comp
                 .tokens
                 .iter()
@@ -163,7 +163,7 @@ impl App {
                     });
                 }
                 None => {
-                    warn!("Received update for unknown pool {}", comp.address)
+                    warn!("Received update for unknown pool {}", comp.id)
                 }
             };
         }
@@ -173,7 +173,7 @@ impl App {
             let entry = self
                 .items
                 .iter()
-                .find_position(|e| e.component.address == eth_address);
+                .find_position(|e| e.component.id == eth_address);
             if let Some((index, _)) = entry {
                 let row = self.items.get_mut(index).unwrap();
                 let price = state.spot_price(&row.component.tokens[0], &row.component.tokens[1]);
@@ -187,7 +187,7 @@ impl App {
                 .items
                 .iter()
                 .enumerate()
-                .find(|(_, e)| e.component.address == comp.address);
+                .find(|(_, e)| e.component.id == comp.id);
             if let Some((idx, _)) = entry {
                 self.items.remove(idx);
             }

--- a/src/evm/decoder.rs
+++ b/src/evm/decoder.rs
@@ -207,7 +207,7 @@ impl TychoStreamDecoder {
                     })
                     .collect::<Result<Vec<_>, StreamDecodeError>>()?
                     .into_iter()
-                    .flat_map(|(id, address, comp)| {
+                    .flat_map(|(id, _, comp)| {
                         let tokens = comp
                             .tokens
                             .iter()
@@ -215,7 +215,7 @@ impl TychoStreamDecoder {
                             .collect::<Vec<_>>();
 
                         if tokens.len() == comp.tokens.len() {
-                            Some((id.clone(), ProtocolComponent::new(address, tokens)))
+                            Some((id.clone(), ProtocolComponent::new(tokens, comp.clone())))
                         } else {
                             // We may reach this point if the removed component
                             //  contained low quality tokens, in this case the component
@@ -274,7 +274,7 @@ impl TychoStreamDecoder {
                 }
                 new_pairs.insert(
                     id.clone(),
-                    ProtocolComponent::new(Bytes::from(id.as_str()), component_tokens),
+                    ProtocolComponent::new(component_tokens, snapshot.component.clone()),
                 );
 
                 // Construct state from snapshot


### PR DESCRIPTION
Also implement From<ProtocolComponent> for tycho_core::dto::ProtocolComponent. This will be useful for tycho-execution

Deprecate address in ProtocolComponent. It should be id instead

(this was decided [here](https://propellerswap.slack.com/archives/C07H7S15LUV/p1738775735122579?thread_ts=1738687888.096819&cid=C07H7S15LUV))