### PR TITLE
feat: add account balance overrides 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7838,7 +7838,7 @@ dependencies = [
 [[package]]
 name = "tycho-client"
 version = "0.56.1"
-source = "git+https://github.com/propeller-heads/tycho-indexer.git?rev=794cdf0#794cdf05d0134f33a5b11a50faa93c7143f33003"
+source = "git+https://github.com/propeller-heads/tycho-indexer.git?rev=09c2837#09c2837c404f381751c3eb71ed6d55965ad0f3aa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7864,7 +7864,7 @@ dependencies = [
 [[package]]
 name = "tycho-core"
 version = "0.56.1"
-source = "git+https://github.com/propeller-heads/tycho-indexer.git?rev=794cdf0#794cdf05d0134f33a5b11a50faa93c7143f33003"
+source = "git+https://github.com/propeller-heads/tycho-indexer.git?rev=09c2837#09c2837c404f381751c3eb71ed6d55965ad0f3aa"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7837,8 +7837,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.56.5"
-source = "git+https://github.com/propeller-heads/tycho-indexer.git?tag=0.56.5#2af8c1a5a61c5479eab5f7903b69943efa61e2c8"
+version = "0.56.1"
+source = "git+https://github.com/propeller-heads/tycho-indexer.git?rev=794cdf0#794cdf05d0134f33a5b11a50faa93c7143f33003"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7863,8 +7863,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-core"
-version = "0.56.5"
-source = "git+https://github.com/propeller-heads/tycho-indexer.git?tag=0.56.5#2af8c1a5a61c5479eab5f7903b69943efa61e2c8"
+version = "0.56.1"
+source = "git+https://github.com/propeller-heads/tycho-indexer.git?rev=794cdf0#794cdf05d0134f33a5b11a50faa93c7143f33003"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7837,8 +7837,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.57.1"
-source = "git+https://github.com/propeller-heads/tycho-indexer.git?tag=0.57.1#7b511da273ad1d7d1e13a27930f32ba4c8b54338"
+version = "0.56.5"
+source = "git+https://github.com/propeller-heads/tycho-indexer.git?tag=0.56.5#2af8c1a5a61c5479eab5f7903b69943efa61e2c8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7863,8 +7863,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-core"
-version = "0.57.1"
-source = "git+https://github.com/propeller-heads/tycho-indexer.git?tag=0.57.1#7b511da273ad1d7d1e13a27930f32ba4c8b54338"
+version = "0.56.5"
+source = "git+https://github.com/propeller-heads/tycho-indexer.git?tag=0.56.5#2af8c1a5a61c5479eab5f7903b69943efa61e2c8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7837,8 +7837,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.56.1"
-source = "git+https://github.com/propeller-heads/tycho-indexer.git?rev=09c2837#09c2837c404f381751c3eb71ed6d55965ad0f3aa"
+version = "0.57.1"
+source = "git+https://github.com/propeller-heads/tycho-indexer.git?tag=0.57.1#7b511da273ad1d7d1e13a27930f32ba4c8b54338"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7863,8 +7863,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-core"
-version = "0.56.1"
-source = "git+https://github.com/propeller-heads/tycho-indexer.git?rev=09c2837#09c2837c404f381751c3eb71ed6d55965ad0f3aa"
+version = "0.57.1"
+source = "git+https://github.com/propeller-heads/tycho-indexer.git?tag=0.57.1#7b511da273ad1d7d1e13a27930f32ba4c8b54338"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ mini-moka = "0.10"
 lazy_static = "1.4.0"
 
 # Tycho dependencies
-tycho-core = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-core", tag = "0.56.5" }
-tycho-client = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-client", tag = "0.56.5" }
+tycho-core = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-core", rev = "794cdf0" }
+tycho-client = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-client", rev = "794cdf0" }
 tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution.git", package = "tycho-execution", features = ["evm"], tag = "0.61.0" }
 
 # EVM dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ mini-moka = "0.10"
 lazy_static = "1.4.0"
 
 # Tycho dependencies
-tycho-core = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-core", rev = "09c2837" }
-tycho-client = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-client", rev = "09c2837" }
+tycho-core = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-core", tag = "0.57.1" }
+tycho-client = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-client", tag = "0.57.1" }
 tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution.git", package = "tycho-execution", features = ["evm"], tag = "0.61.0" }
 
 # EVM dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ mini-moka = "0.10"
 lazy_static = "1.4.0"
 
 # Tycho dependencies
-tycho-core = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-core", tag = "0.57.1" }
-tycho-client = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-client", tag = "0.57.1" }
+tycho-core = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-core", tag = "0.56.5" }
+tycho-client = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-client", tag = "0.56.5" }
 tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution.git", package = "tycho-execution", features = ["evm"], tag = "0.61.0" }
 
 # EVM dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ mini-moka = "0.10"
 lazy_static = "1.4.0"
 
 # Tycho dependencies
-tycho-core = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-core", rev = "794cdf0" }
-tycho-client = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-client", rev = "794cdf0" }
+tycho-core = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-core", rev = "09c2837" }
+tycho-client = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-client", rev = "09c2837" }
 tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution.git", package = "tycho-execution", features = ["evm"], tag = "0.61.0" }
 
 # EVM dependencies

--- a/src/evm/decoder.rs
+++ b/src/evm/decoder.rs
@@ -113,7 +113,7 @@ impl TychoStreamDecoder {
         let decoder = Box::new(
             move |component: ComponentWithState,
                   header: Header,
-                  account_balances: HashMap<Bytes, HashMap<Bytes, Bytes>>,
+                  account_balances: AccountBalances,
                   state: Arc<RwLock<DecoderState>>| {
                 Box::pin(async move {
                     let guard = state.read().await;

--- a/src/evm/decoder.rs
+++ b/src/evm/decoder.rs
@@ -560,7 +560,6 @@ mod tests {
     }
 
     fn load_test_msg(name: &str) -> FeedMessage {
-        dbg!(&name);
         let project_root = env!("CARGO_MANIFEST_DIR");
         let asset_path =
             Path::new(project_root).join(format!("tests/assets/decoder/{}.json", name));

--- a/src/evm/engine_db/mod.rs
+++ b/src/evm/engine_db/mod.rs
@@ -90,7 +90,7 @@ pub async fn update_engine(
                 address: vm_storage_values.address,
                 chain: vm_storage_values.chain,
                 slots: vm_storage_values.slots.clone(),
-                balance: Some(vm_storage_values.balance),
+                balance: Some(vm_storage_values.native_balance),
                 code: Some(vm_storage_values.code.clone()),
                 change: ChangeType::Creation,
             });

--- a/src/evm/protocol/uniswap_v2/state.rs
+++ b/src/evm/protocol/uniswap_v2/state.rs
@@ -10,7 +10,7 @@ use crate::{
         safe_math::{safe_add_u256, safe_div_u256, safe_mul_u256, safe_sub_u256},
         u256_num::{biguint_to_u256, u256_to_biguint},
     },
-    models::Token,
+    models::{Balances, Token},
     protocol::{
         errors::{SimulationError, TransitionError},
         models::GetAmountOutResult,
@@ -104,6 +104,7 @@ impl ProtocolSim for UniswapV2State {
         &mut self,
         delta: ProtocolStateDelta,
         _tokens: &HashMap<Bytes, Token>,
+        _balances: &Balances,
     ) -> Result<(), TransitionError<String>> {
         // reserve0 and reserve1 are considered required attributes and are expected in every delta
         // we process
@@ -300,7 +301,7 @@ mod tests {
             deleted_attributes: HashSet::new(), // usv2 doesn't have any deletable attributes
         };
 
-        let res = state.delta_transition(delta, &HashMap::new());
+        let res = state.delta_transition(delta, &HashMap::new(), &Balances::default());
 
         assert!(res.is_ok());
         assert_eq!(state.reserve0, U256::from_str("1500").unwrap());
@@ -321,7 +322,7 @@ mod tests {
             deleted_attributes: HashSet::new(),
         };
 
-        let res = state.delta_transition(delta, &HashMap::new());
+        let res = state.delta_transition(delta, &HashMap::new(), &Balances::default());
 
         assert!(res.is_err());
         // assert it errors for the missing reserve1 attribute delta

--- a/src/evm/protocol/uniswap_v2/tycho_decoder.rs
+++ b/src/evm/protocol/uniswap_v2/tycho_decoder.rs
@@ -18,6 +18,7 @@ impl TryFromWithBlock<ComponentWithState> for UniswapV2State {
     async fn try_from_with_block(
         snapshot: ComponentWithState,
         _block: Header,
+        _account_balances: &HashMap<Bytes, HashMap<Bytes, Bytes>>,
         _all_tokens: &HashMap<Bytes, Token>,
     ) -> Result<Self, Self::Error> {
         let reserve0 = U256::from_be_slice(
@@ -42,13 +43,10 @@ impl TryFromWithBlock<ComponentWithState> for UniswapV2State {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, str::FromStr};
+    use std::str::FromStr;
 
     use chrono::DateTime;
-    use tycho_core::{
-        dto::{Chain, ChangeType, ProtocolComponent, ResponseProtocolState},
-        hex_bytes::Bytes,
-    };
+    use tycho_core::dto::{Chain, ChangeType, ProtocolComponent, ResponseProtocolState};
 
     use super::*;
 
@@ -97,7 +95,13 @@ mod tests {
             component: usv2_component(),
         };
 
-        let result = UniswapV2State::try_from_with_block(snapshot, header(), &HashMap::new()).await;
+        let result = UniswapV2State::try_from_with_block(
+            snapshot,
+            header(),
+            &HashMap::new(),
+            &HashMap::new(),
+        )
+        .await;
 
         assert!(result.is_ok());
         let res = result.unwrap();
@@ -120,7 +124,13 @@ mod tests {
             component: usv2_component(),
         };
 
-        let result = UniswapV2State::try_from_with_block(snapshot, header(), &HashMap::new()).await;
+        let result = UniswapV2State::try_from_with_block(
+            snapshot,
+            header(),
+            &HashMap::new(),
+            &HashMap::new(),
+        )
+        .await;
 
         assert!(result.is_err());
 

--- a/src/evm/protocol/uniswap_v3/state.rs
+++ b/src/evm/protocol/uniswap_v3/state.rs
@@ -22,7 +22,7 @@ use crate::{
             StepComputation, SwapResults, SwapState,
         },
     },
-    models::Token,
+    models::{Balances, Token},
     protocol::{
         errors::{SimulationError, TransitionError},
         models::GetAmountOutResult,
@@ -266,6 +266,7 @@ impl ProtocolSim for UniswapV3State {
         &mut self,
         delta: ProtocolStateDelta,
         _tokens: &HashMap<Bytes, Token>,
+        _balances: &Balances,
     ) -> Result<(), TransitionError<String>> {
         // apply attribute changes
         if let Some(liquidity) = delta
@@ -619,7 +620,7 @@ mod tests {
             deleted_attributes: HashSet::new(),
         };
 
-        pool.delta_transition(delta, &HashMap::new())
+        pool.delta_transition(delta, &HashMap::new(), &Balances::default())
             .unwrap();
 
         assert_eq!(pool.liquidity, 2000);

--- a/src/evm/protocol/uniswap_v3/tycho_decoder.rs
+++ b/src/evm/protocol/uniswap_v3/tycho_decoder.rs
@@ -19,6 +19,7 @@ impl TryFromWithBlock<ComponentWithState> for UniswapV3State {
     async fn try_from_with_block(
         snapshot: ComponentWithState,
         _block: Header,
+        _account_balances: &HashMap<Bytes, HashMap<Bytes, Bytes>>,
         _all_tokens: &HashMap<Bytes, Token>,
     ) -> Result<Self, Self::Error> {
         let liq = snapshot
@@ -126,14 +127,11 @@ impl TryFromWithBlock<ComponentWithState> for UniswapV3State {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, str::FromStr};
+    use std::str::FromStr;
 
     use chrono::DateTime;
     use rstest::rstest;
-    use tycho_core::{
-        dto::{Chain, ChangeType, ProtocolComponent, ResponseProtocolState},
-        hex_bytes::Bytes,
-    };
+    use tycho_core::dto::{Chain, ChangeType, ProtocolComponent, ResponseProtocolState};
 
     use super::*;
 
@@ -191,7 +189,13 @@ mod tests {
             component: usv3_component(),
         };
 
-        let result = UniswapV3State::try_from_with_block(snapshot, header(), &HashMap::new()).await;
+        let result = UniswapV3State::try_from_with_block(
+            snapshot,
+            header(),
+            &HashMap::new(),
+            &HashMap::new(),
+        )
+        .await;
 
         assert!(result.is_ok());
         let expected = UniswapV3State::new(
@@ -240,7 +244,13 @@ mod tests {
             component,
         };
 
-        let result = UniswapV3State::try_from_with_block(snapshot, header(), &HashMap::new()).await;
+        let result = UniswapV3State::try_from_with_block(
+            snapshot,
+            header(),
+            &HashMap::new(),
+            &HashMap::new(),
+        )
+        .await;
 
         assert!(result.is_err());
         assert!(matches!(
@@ -266,7 +276,13 @@ mod tests {
             component,
         };
 
-        let result = UniswapV3State::try_from_with_block(snapshot, header(), &HashMap::new()).await;
+        let result = UniswapV3State::try_from_with_block(
+            snapshot,
+            header(),
+            &HashMap::new(),
+            &HashMap::new(),
+        )
+        .await;
 
         assert!(result.is_err());
         assert!(matches!(

--- a/src/evm/protocol/uniswap_v4/state.rs
+++ b/src/evm/protocol/uniswap_v4/state.rs
@@ -21,7 +21,7 @@ use crate::{
             StepComputation, SwapResults, SwapState,
         },
     },
-    models::Token,
+    models::{Balances, Token},
     protocol::{
         errors::{SimulationError, TransitionError},
         models::GetAmountOutResult,
@@ -284,6 +284,7 @@ impl ProtocolSim for UniswapV4State {
         &mut self,
         delta: ProtocolStateDelta,
         _tokens: &HashMap<Bytes, Token>,
+        _balances: &Balances,
     ) -> Result<(), TransitionError<String>> {
         // Apply attribute changes
         if let Some(liquidity) = delta
@@ -417,7 +418,7 @@ mod tests {
             deleted_attributes: HashSet::new(),
         };
 
-        pool.delta_transition(delta, &HashMap::new())
+        pool.delta_transition(delta, &HashMap::new(), &Balances::default())
             .unwrap();
 
         assert_eq!(pool.liquidity, 2000);

--- a/src/evm/protocol/uniswap_v4/state.rs
+++ b/src/evm/protocol/uniswap_v4/state.rs
@@ -455,10 +455,14 @@ mod tests {
         let state: ComponentWithState = serde_json::from_value(data)
             .expect("Expected json to match ComponentWithState structure");
 
-        let usv4_state =
-            UniswapV4State::try_from_with_block(state, Default::default(), &Default::default())
-                .await
-                .unwrap();
+        let usv4_state = UniswapV4State::try_from_with_block(
+            state,
+            Default::default(),
+            &Default::default(),
+            &Default::default(),
+        )
+        .await
+        .unwrap();
 
         let t0 = Token::new(
             "0x647e32181a64f4ffd4f0b0b4b052ec05b277729c",

--- a/src/evm/protocol/uniswap_v4/tycho_decoder.rs
+++ b/src/evm/protocol/uniswap_v4/tycho_decoder.rs
@@ -22,6 +22,7 @@ impl TryFromWithBlock<ComponentWithState> for UniswapV4State {
     async fn try_from_with_block(
         snapshot: ComponentWithState,
         _block: Header,
+        _account_balances: &HashMap<Bytes, HashMap<Bytes, Bytes>>,
         _all_tokens: &HashMap<Bytes, Token>,
     ) -> Result<Self, Self::Error> {
         let liq = snapshot
@@ -126,14 +127,11 @@ impl TryFromWithBlock<ComponentWithState> for UniswapV4State {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, str::FromStr};
+    use std::str::FromStr;
 
     use chrono::DateTime;
     use rstest::rstest;
-    use tycho_core::{
-        dto::{Chain, ChangeType, ProtocolComponent, ResponseProtocolState},
-        hex_bytes::Bytes,
-    };
+    use tycho_core::dto::{Chain, ChangeType, ProtocolComponent, ResponseProtocolState};
 
     use super::*;
 
@@ -198,9 +196,14 @@ mod tests {
             component: usv4_component(),
         };
 
-        let result = UniswapV4State::try_from_with_block(snapshot, header(), &HashMap::new())
-            .await
-            .unwrap();
+        let result = UniswapV4State::try_from_with_block(
+            snapshot,
+            header(),
+            &HashMap::new(),
+            &HashMap::new(),
+        )
+        .await
+        .unwrap();
 
         let fees = UniswapV4Fees::new(0, 0, 500);
         let expected = UniswapV4State::new(
@@ -252,7 +255,13 @@ mod tests {
             component,
         };
 
-        let result = UniswapV4State::try_from_with_block(snapshot, header(), &HashMap::new()).await;
+        let result = UniswapV4State::try_from_with_block(
+            snapshot,
+            header(),
+            &HashMap::new(),
+            &HashMap::new(),
+        )
+        .await;
 
         assert!(result.is_err());
         assert!(matches!(

--- a/src/evm/protocol/vm/state.rs
+++ b/src/evm/protocol/vm/state.rs
@@ -298,8 +298,8 @@ where
     ///
     /// # Returns
     ///
-    /// * `Result<(), SimulationError>` - A `Result` containing the sell amount limit on success or
-    ///   a `SimulationError` on failure.
+    /// * `Result<U256, SimulationError>` - Returns the sell amount limit as a `U256` if successful,
+    ///   or a `SimulationError` on failure.
     fn get_sell_amount_limit(
         &self,
         tokens: Vec<Address>,
@@ -316,6 +316,16 @@ where
         Ok(limits?.0)
     }
 
+    /// Updates the pool state.
+    ///
+    /// It is assumed this is called on a new block. Therefore, first the pool's overwrites cache is
+    /// cleared, then the balances are updated and the spot prices are recalculated.
+    ///
+    /// # Arguments
+    ///
+    /// * `tokens` - A hashmap of token addresses to `Token` instances. This is necessary for
+    ///   calculating new spot prices.
+    /// * `balances` - A `Balances` instance containing all balance updates on the current block.
     fn update_pool_state(
         &mut self,
         tokens: &HashMap<Bytes, Token>,
@@ -428,6 +438,16 @@ where
             .fold(HashMap::new(), |acc, overwrite| self.merge(&acc, &overwrite)))
     }
 
+    /// Gets all balance overwrites for the pool's tokens.
+    ///
+    /// If the pool uses component balances, the balances are set for the balance owner (if exists)
+    /// or for the pool itself. If the pool uses contract balances, the balances are set for the
+    /// contracts involved in the pool.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<HashMap<Address, Overwrites>, SimulationError>` - Returns a hashmap of address to
+    ///   `Overwrites` if successful, or a `SimulationError` on failure.
     fn get_balance_overwrites(&self) -> Result<HashMap<Address, Overwrites>, SimulationError> {
         let mut balance_overwrites: HashMap<Address, Overwrites> = HashMap::new();
         if !self.balances.is_empty() {

--- a/src/evm/protocol/vm/state_builder.rs
+++ b/src/evm/protocol/vm/state_builder.rs
@@ -491,10 +491,7 @@ mod tests {
     use alloy_primitives::B256;
 
     use super::*;
-    use crate::evm::{
-        engine_db::{tycho_db::PreCachedDB, SHARED_TYCHO_DB},
-        protocol::vm::constants::BALANCER_V2,
-    };
+    use crate::evm::engine_db::{tycho_db::PreCachedDB, SHARED_TYCHO_DB};
 
     #[test]
     fn test_build_without_required_fields() {

--- a/src/evm/protocol/vm/state_builder.rs
+++ b/src/evm/protocol/vm/state_builder.rs
@@ -97,6 +97,7 @@ where
     balance_owner: Option<Address>,
     capabilities: Option<HashSet<Capability>>,
     involved_contracts: Option<HashSet<Address>>,
+    contract_balances: HashMap<Address, HashMap<Address, U256>>,
     stateless_contracts: Option<HashMap<String, Option<Vec<u8>>>>,
     token_storage_slots: Option<HashMap<Address, (ERC20Slots, ContractCompiler)>>,
     manual_updates: Option<bool>,
@@ -115,19 +116,19 @@ where
     pub fn new(
         id: String,
         tokens: Vec<TychoBytes>,
-        balances: HashMap<Address, U256>,
         block: BlockHeader,
         adapter_address: Address,
     ) -> Self {
         Self {
             id,
             tokens,
-            balances,
+            balances: HashMap::new(),
             block,
             adapter_address,
             balance_owner: None,
             capabilities: None,
             involved_contracts: None,
+            contract_balances: HashMap::new(),
             stateless_contracts: None,
             token_storage_slots: None,
             manual_updates: None,
@@ -140,6 +141,19 @@ where
 
     pub fn balance_owner(mut self, balance_owner: Address) -> Self {
         self.balance_owner = Some(balance_owner);
+        self
+    }
+
+    pub fn balances(mut self, balances: HashMap<Address, U256>) -> Self {
+        self.balances = balances;
+        self
+    }
+
+    pub fn account_balances(
+        mut self,
+        account_balances: HashMap<Address, HashMap<Address, U256>>,
+    ) -> Self {
+        self.contract_balances = account_balances;
         self
     }
 
@@ -221,26 +235,58 @@ where
         } else {
             self.get_default_capabilities()?
         };
-        Ok(EVMPoolState::new(
-            self.id,
-            self.tokens,
-            self.block,
-            self.balances,
-            self.balance_owner,
-            HashMap::new(),
-            capabilities,
-            HashMap::new(),
-            self.involved_contracts
-                .unwrap_or_default(),
-            self.token_storage_slots
-                .unwrap_or_default(),
-            self.manual_updates.unwrap_or(false),
-            self.adapter_contract.ok_or_else(|| {
-                SimulationError::FatalError(
-                    "Failed to get build engine: Adapter contract not initialized".to_string(),
-                )
-            })?,
-        ))
+
+        let adapter_contract = self.adapter_contract.ok_or_else(|| {
+            SimulationError::FatalError(
+                "Failed to get build engine: Adapter contract not initialized".to_string(),
+            )
+        })?;
+
+        if !self.contract_balances.is_empty() {
+            // Use contract balances to build the state
+            if !self.balances.is_empty() {
+                warn!("Both contract balances and component balances are set. Contract balances will be used.");
+            }
+            Ok(EVMPoolState::new(
+                self.id,
+                self.tokens,
+                self.block,
+                self.contract_balances,
+                HashMap::new(),
+                capabilities,
+                HashMap::new(),
+                self.involved_contracts
+                    .unwrap_or_default(),
+                self.token_storage_slots
+                    .unwrap_or_default(),
+                self.manual_updates.unwrap_or(false),
+                adapter_contract,
+            ))
+        } else {
+            // Use component balances to build the state
+            if self.balances.is_empty() {
+                return Err(SimulationError::FatalError(
+                    "Failed to get build EVMPoolState: no balances were set".to_string(),
+                ));
+            }
+            #[allow(deprecated)]
+            Ok(EVMPoolState::new_with_component_balances(
+                self.id,
+                self.tokens,
+                self.block,
+                self.balances,
+                self.balance_owner,
+                HashMap::new(),
+                capabilities,
+                HashMap::new(),
+                self.involved_contracts
+                    .unwrap_or_default(),
+                self.token_storage_slots
+                    .unwrap_or_default(),
+                self.manual_updates.unwrap_or(false),
+                adapter_contract,
+            ))
+        }
     }
 
     async fn get_default_engine(&self, db: D) -> Result<SimulationEngine<D>, SimulationError> {
@@ -457,7 +503,7 @@ mod tests {
     use super::*;
     use crate::evm::{
         engine_db::{tycho_db::PreCachedDB, SHARED_TYCHO_DB},
-        protocol::utils::bytes_to_address,
+        protocol::vm::constants::BALANCER_V2,
     };
 
     #[test]
@@ -470,7 +516,8 @@ mod tests {
         let adapter_address =
             Address::from_str("0xA2C5C98A892fD6656a7F39A2f63228C0Bc846270").unwrap();
         let result = tokio_test::block_on(
-            EVMPoolStateBuilder::<PreCachedDB>::new(id, tokens, balances, block, adapter_address)
+            EVMPoolStateBuilder::<PreCachedDB>::new(id, tokens, block, adapter_address)
+                .balances(balances)
                 .build(SHARED_TYCHO_DB.clone()),
         );
 
@@ -478,6 +525,31 @@ mod tests {
         match result.unwrap_err() {
             SimulationError::FatalError(field) => {
                 assert_eq!(field, "Adapter contract bytecode not set")
+            }
+            _ => panic!("Unexpected error type"),
+        }
+    }
+
+    #[test]
+    fn test_build_without_balances() {
+        let id = "0x4626d81b3a1711beb79f4cecff2413886d461677000200000000000000000011".to_string();
+        let tokens = vec![
+            TychoBytes::from_str("0x6b175474e89094c44da98b954eedeac495271d0f").unwrap(),
+            TychoBytes::from_str("0xba100000625a3754423978a60c9317c58a424e3d").unwrap(),
+        ];
+        let block = BlockHeader { number: 1, hash: B256::default(), timestamp: 234 };
+        let adapter_address =
+            Address::from_str("0xA2C5C98A892fD6656a7F39A2f63228C0Bc846270").unwrap();
+        let result = tokio_test::block_on(
+            EVMPoolStateBuilder::<PreCachedDB>::new(id, tokens, block, adapter_address)
+                .adapter_contract_bytecode(Bytecode::new_raw(BALANCER_V2.into()))
+                .build(SHARED_TYCHO_DB.clone()),
+        );
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            SimulationError::FatalError(field) => {
+                assert_eq!(field, "Failed to get build EVMPoolState: no balances were set")
             }
             _ => panic!("Unexpected error type"),
         }
@@ -493,8 +565,8 @@ mod tests {
         let balances = HashMap::new();
         let adapter_address =
             Address::from_str("0xA2C5C98A892fD6656a7F39A2f63228C0Bc846270").unwrap();
-        let builder =
-            EVMPoolStateBuilder::<PreCachedDB>::new(id, tokens, balances, block, adapter_address);
+        let builder = EVMPoolStateBuilder::<PreCachedDB>::new(id, tokens, block, adapter_address)
+            .balances(balances);
 
         let engine =
             tokio_test::block_on(builder.get_default_engine(SHARED_TYCHO_DB.clone())).unwrap();

--- a/src/evm/protocol/vm/state_builder.rs
+++ b/src/evm/protocol/vm/state_builder.rs
@@ -76,7 +76,8 @@ use crate::{
 ///     balances.insert(Address::random(), U256::from(1000));
 ///
 ///     // Build the EVMPoolState
-///     let pool_state = EVMPoolStateBuilder::new(pool_id, tokens, balances, block, Address::random())
+///     let pool_state = EVMPoolStateBuilder::new(pool_id, tokens, block, Address::random())
+///         .balances(balances)
 ///         .balance_owner(Address::random())
 ///         .adapter_contract_bytecode(Bytecode::new_raw(BALANCER_V2.into()))
 ///         .build(SHARED_TYCHO_DB.clone())
@@ -144,11 +145,13 @@ where
         self
     }
 
+    /// Set component balances
     pub fn balances(mut self, balances: HashMap<Address, U256>) -> Self {
         self.balances = balances;
         self
     }
 
+    /// Set contract balances
     pub fn account_balances(
         mut self,
         account_balances: HashMap<Address, HashMap<Address, U256>>,

--- a/src/evm/protocol/vm/state_builder.rs
+++ b/src/evm/protocol/vm/state_builder.rs
@@ -521,31 +521,6 @@ mod tests {
     }
 
     #[test]
-    fn test_build_without_balances() {
-        let id = "0x4626d81b3a1711beb79f4cecff2413886d461677000200000000000000000011".to_string();
-        let tokens = vec![
-            TychoBytes::from_str("0x6b175474e89094c44da98b954eedeac495271d0f").unwrap(),
-            TychoBytes::from_str("0xba100000625a3754423978a60c9317c58a424e3d").unwrap(),
-        ];
-        let block = BlockHeader { number: 1, hash: B256::default(), timestamp: 234 };
-        let adapter_address =
-            Address::from_str("0xA2C5C98A892fD6656a7F39A2f63228C0Bc846270").unwrap();
-        let result = tokio_test::block_on(
-            EVMPoolStateBuilder::<PreCachedDB>::new(id, tokens, block, adapter_address)
-                .adapter_contract_bytecode(Bytecode::new_raw(BALANCER_V2.into()))
-                .build(SHARED_TYCHO_DB.clone()),
-        );
-
-        assert!(result.is_err());
-        match result.unwrap_err() {
-            SimulationError::FatalError(field) => {
-                assert_eq!(field, "Failed to get build EVMPoolState: no balances were set")
-            }
-            _ => panic!("Unexpected error type"),
-        }
-    }
-
-    #[test]
     fn test_engine_setup() {
         let id = "pool_1".to_string();
         let token2 = TychoBytes::from_str("0000000000000000000000000000000000000002").unwrap();

--- a/src/evm/protocol/vm/tycho_decoder.rs
+++ b/src/evm/protocol/vm/tycho_decoder.rs
@@ -151,17 +151,13 @@ impl TryFromWithBlock<ComponentWithState> for EVMPoolState<PreCachedDB> {
             Address::from_str(&format!("{:0>40}", hex::encode(protocol_name)))
                 .expect("Can't convert protocol name to address");
 
-        let mut pool_state_builder = EVMPoolStateBuilder::new(
-            id.clone(),
-            tokens.clone(),
-            balances,
-            block,
-            adapter_contract_address,
-        )
-        .adapter_contract_bytecode(adapter_bytecode)
-        .involved_contracts(involved_contracts)
-        .stateless_contracts(stateless_contracts)
-        .manual_updates(manual_updates);
+        let mut pool_state_builder =
+            EVMPoolStateBuilder::new(id.clone(), tokens.clone(), block, adapter_contract_address)
+                .balances(balances)
+                .adapter_contract_bytecode(adapter_bytecode)
+                .involved_contracts(involved_contracts)
+                .stateless_contracts(stateless_contracts)
+                .manual_updates(manual_updates);
 
         if let Some(balance_owner) = balance_owner {
             pool_state_builder = pool_state_builder.balance_owner(balance_owner)
@@ -250,6 +246,7 @@ mod tests {
         accounts
     }
 
+    #[allow(deprecated)]
     #[tokio::test]
     async fn test_try_from_with_block() {
         let attributes: HashMap<String, Bytes> = vec![

--- a/src/evm/protocol/vm/tycho_decoder.rs
+++ b/src/evm/protocol/vm/tycho_decoder.rs
@@ -42,7 +42,8 @@ impl From<Header> for BlockHeader {
 impl TryFromWithBlock<ComponentWithState> for EVMPoolState<PreCachedDB> {
     type Error = InvalidSnapshotError;
 
-    /// Decodes a `ComponentWithState` into an `EVMPoolState`.
+    /// Decodes a `ComponentWithState`, block `Header` and HashMap of all available tokens into an
+    /// `EVMPoolState`.
     ///
     /// Errors with a `InvalidSnapshotError`.
     async fn try_from_with_block(

--- a/src/evm/protocol/vm/tycho_decoder.rs
+++ b/src/evm/protocol/vm/tycho_decoder.rs
@@ -148,8 +148,11 @@ impl TryFromWithBlock<ComponentWithState> for EVMPoolState<PreCachedDB> {
             });
         let adapter_bytecode = Bytecode::new_raw(get_adapter_file(protocol_name)?.into());
         let adapter_contract_address =
-            Address::from_str(&format!("{:0>40}", hex::encode(protocol_name)))
-                .expect("Can't convert protocol name to address");
+            Address::from_str(&format!("{:0>40}", hex::encode(protocol_name))).map_err(|_| {
+                InvalidSnapshotError::ValueError(
+                    "Error converting protocol name to address".to_string(),
+                )
+            })?;
 
         let mut pool_state_builder =
             EVMPoolStateBuilder::new(id.clone(), tokens.clone(), block, adapter_contract_address)

--- a/src/evm/tycho_models.rs
+++ b/src/evm/tycho_models.rs
@@ -201,7 +201,8 @@ pub struct ResponseAccount {
     pub address: Address,
     pub title: String,
     pub slots: HashMap<U256, U256>,
-    pub balance: U256,
+    pub native_balance: U256,
+    pub token_balances: HashMap<Address, U256>,
     #[serde(with = "hex_bytes")]
     pub code: Vec<u8>,
     pub code_hash: B256,
@@ -217,7 +218,8 @@ impl ResponseAccount {
         address: Address,
         title: String,
         slots: HashMap<U256, U256>,
-        balance: U256,
+        native_balance: U256,
+        token_balances: HashMap<Address, U256>,
         code: Vec<u8>,
         code_hash: B256,
         balance_modify_tx: B256,
@@ -229,7 +231,8 @@ impl ResponseAccount {
             address,
             title,
             slots,
-            balance,
+            native_balance,
+            token_balances,
             code,
             code_hash,
             balance_modify_tx,
@@ -247,7 +250,8 @@ impl std::fmt::Debug for ResponseAccount {
             .field("address", &self.address)
             .field("title", &self.title)
             .field("slots", &self.slots)
-            .field("balance", &self.balance)
+            .field("native_balance", &self.native_balance)
+            .field("token_balances", &self.token_balances)
             .field("code", &format!("[{} bytes]", self.code.len()))
             .field("code_hash", &self.code_hash)
             .field("balance_modify_tx", &self.balance_modify_tx)
@@ -264,7 +268,14 @@ impl From<tycho_core::dto::ResponseAccount> for ResponseAccount {
             address: Address::from_slice(&value.address[..20]), // Convert address field to Address
             title: value.title.clone(),
             slots: u256_num::map_slots_to_u256(value.slots),
-            balance: u256_num::bytes_to_u256(value.native_balance.into()),
+            native_balance: u256_num::bytes_to_u256(value.native_balance.into()),
+            token_balances: value
+                .token_balances
+                .into_iter()
+                .map(|(address, balance)| {
+                    (Address::from_slice(&address[..20]), u256_num::bytes_to_u256(balance.into()))
+                })
+                .collect(),
             code: value.code.to_vec(),
             code_hash: B256::from_slice(&value.code_hash[..]),
             balance_modify_tx: B256::from_slice(&value.balance_modify_tx[..]),

--- a/src/models.rs
+++ b/src/models.rs
@@ -5,6 +5,7 @@
 //!
 //! Tokens provide instructions on how to handle prices and amounts.
 use std::{
+    collections::HashMap,
     convert::TryFrom,
     hash::{Hash, Hasher},
 };
@@ -101,6 +102,12 @@ impl TryFrom<ResponseToken> for Token {
             ),
         })
     }
+}
+
+#[derive(Default)]
+pub struct Balances {
+    pub component_balances: HashMap<String, HashMap<Bytes, Bytes>>,
+    pub account_balances: HashMap<Bytes, HashMap<Bytes, Bytes>>,
 }
 
 #[cfg(test)]

--- a/src/protocol/models.rs
+++ b/src/protocol/models.rs
@@ -130,6 +130,7 @@ pub trait TryFromWithBlock<T> {
     fn try_from_with_block(
         value: T,
         block: Header,
+        account_balances: &HashMap<Bytes, HashMap<Bytes, Bytes>>,
         all_tokens: &HashMap<Bytes, Token>,
     ) -> impl Future<Output = Result<Self, Self::Error>> + Send + Sync
     where

--- a/src/protocol/state.rs
+++ b/src/protocol/state.rs
@@ -52,7 +52,7 @@ use num_bigint::BigUint;
 use tycho_core::{dto::ProtocolStateDelta, Bytes};
 
 use crate::{
-    models::Token,
+    models::{Balances, Token},
     protocol::{
         errors::{SimulationError, TransitionError},
         models::GetAmountOutResult,
@@ -121,6 +121,7 @@ pub trait ProtocolSim: std::fmt::Debug + Send + Sync + 'static {
         &mut self,
         delta: ProtocolStateDelta,
         tokens: &HashMap<Bytes, Token>,
+        balances: &Balances,
     ) -> Result<(), TransitionError<String>>;
 
     /// Clones the protocol state as a trait object.
@@ -161,6 +162,7 @@ mock! {
             &mut self,
             delta: ProtocolStateDelta,
             tokens: &HashMap<Bytes, Token>,
+            balances: &Balances,
         ) -> Result<(), TransitionError<String>>;
         pub fn clone_box(&self) -> Box<dyn ProtocolSim>;
         pub fn eq(&self, other: &dyn ProtocolSim) -> bool;
@@ -190,8 +192,9 @@ impl ProtocolSim for MockProtocolSim {
         &mut self,
         delta: ProtocolStateDelta,
         tokens: &HashMap<Bytes, Token>,
+        balances: &Balances,
     ) -> Result<(), TransitionError<String>> {
-        self.delta_transition(delta, tokens)
+        self.delta_transition(delta, tokens, balances)
     }
 
     fn clone_box(&self) -> Box<dyn ProtocolSim> {

--- a/tests/assets/decoder/balancer_v2_delta.json
+++ b/tests/assets/decoder/balancer_v2_delta.json
@@ -58,6 +58,7 @@
             }
           }
         },
+        "account_balances": {},
         "component_tvl": {
           "0x93d199263632a4ef4bb438f1feb99e57b4b5f0bd0000000000000000000005c2": 12902.997863620163
         }

--- a/tests/assets/decoder/uniswap_v2_delta.json
+++ b/tests/assets/decoder/uniswap_v2_delta.json
@@ -55,6 +55,7 @@
             }
           }
         },
+        "account_balances": {},
         "component_tvl": {
           "0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852": 24795.15956433103
         }

--- a/tests/assets/decoder/uniswap_v2_snapshot.json
+++ b/tests/assets/decoder/uniswap_v2_snapshot.json
@@ -61,6 +61,7 @@
         "new_protocol_components": {},
         "deleted_protocol_components": {},
         "component_balances": {},
+        "account_balances": {},
         "component_tvl": {}
       },
       "removed_components": {

--- a/tests/assets/decoder/uniswap_v2_snapshot_broken_id.json
+++ b/tests/assets/decoder/uniswap_v2_snapshot_broken_id.json
@@ -61,6 +61,7 @@
         "new_protocol_components": {},
         "deleted_protocol_components": {},
         "component_balances": {},
+        "account_balances": {},
         "component_tvl": {}
       },
       "removed_components": {

--- a/tests/assets/decoder/uniswap_v2_snapshot_broken_state.json
+++ b/tests/assets/decoder/uniswap_v2_snapshot_broken_state.json
@@ -60,6 +60,7 @@
         "new_protocol_components": {},
         "deleted_protocol_components": {},
         "component_balances": {},
+        "account_balances": {},
         "component_tvl": {}
       },
       "removed_components": {

--- a/tycho_simulation_py/python/tycho_simulation_py/evm/decoders.py
+++ b/tycho_simulation_py/python/tycho_simulation_py/evm/decoders.py
@@ -144,7 +144,11 @@ class ThirdPartyPoolTychoDecoder(TychoDecoder):
         balances = self.decode_balances(snapshot.state.balances, tokens)
 
         # contract balances
-        contract_balances = {to_checksum_address(addr):self.decode_balances(bals) for addr, bals in account_balances if addr in component.contract_ids}
+        contract_balances = {
+            to_checksum_address(addr): self.decode_balances(bals, tokens)
+            for addr, bals in account_balances.items()
+            if addr in component.contract_ids
+        }
 
         optional_attributes = self.decode_optional_attributes(state_attributes)
         pool_id = component.id

--- a/tycho_simulation_py/python/tycho_simulation_py/evm/pool_state.py
+++ b/tycho_simulation_py/python/tycho_simulation_py/evm/pool_state.py
@@ -356,7 +356,16 @@ class ThirdPartyPool:
             # use contract balances for overrides
             balances_by_token = dict()
             for contract, balances in self.contract_balances.items():
-                for token, amount in balances.items():
+                for token_address, amount in balances.items():
+                    token: Optional[EthereumToken] = None
+                    for t in self.tokens:
+                        if t.address.lower() == token_address.lower():
+                            token = t
+                            break
+                    if token is None:
+                        log.warning("Found balance for token not in pool. Overwrite skipped")
+                        continue
+                    amount = token.to_onchain_amount(amount)
                     if token in balances_by_token:
                         balances_by_token[token].append((contract, amount))
                     else:
@@ -395,6 +404,7 @@ class ThirdPartyPool:
             id_=self.id_,
             tokens=self.tokens,
             balances=self.balances,
+            contract_balances=self.contract_balances,
             block=self.block,
             marginal_prices=self.marginal_prices.copy(),
             adapter_contract_path=self.adapter_contract_path,


### PR DESCRIPTION
For some protocols the balances used by a component is stored on a separate contract. To best cater for such components we now support using account_balances where the balance for relevant contracts is monitored and overwritten during simulation.

Decisions:
- it was decided to work towards deprecating the use 'balance_owners' and instead encourage using account balances. For backwards compatibility, support for protocols using balance_owner has been maintained.