### PR TITLE
refactor: make TickList public

### DIFF
--- a/src/evm/protocol/mod.rs
+++ b/src/evm/protocol/mod.rs
@@ -4,5 +4,5 @@ pub mod u256_num;
 pub mod uniswap_v2;
 pub mod uniswap_v3;
 pub mod uniswap_v4;
-pub(crate) mod utils;
+pub mod utils;
 pub mod vm;

--- a/src/evm/protocol/utils/mod.rs
+++ b/src/evm/protocol/utils/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) mod uniswap;
+pub mod uniswap;
 
 use alloy_primitives::Address;
 use tycho_core::Bytes;

--- a/src/evm/protocol/utils/uniswap/mod.rs
+++ b/src/evm/protocol/utils/uniswap/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod liquidity_math;
 mod solidity_math;
 pub(crate) mod sqrt_price_math;
 pub(crate) mod swap_math;
-pub(crate) mod tick_list;
+pub mod tick_list;
 pub(crate) mod tick_math;
 
 #[derive(Debug)]


### PR DESCRIPTION
Resolves https://github.com/propeller-heads/tycho-simulation/issues/138
External users are unable to use UniswapV3::new fn properly as they do not have access to the TickList struct.