### PR TITLE
feat(price_printer): display the protocol name for each row in the table

### DIFF
--- a/examples/price_printer/ui.rs
+++ b/examples/price_printer/ui.rs
@@ -69,8 +69,8 @@ struct Data {
 }
 
 impl Data {
-    const fn ref_array(&self) -> [&String; 3] {
-        [&self.name, &self.tokens, &self.price]
+    const fn ref_array(&self) -> [&String; 4] {
+        [&self.name, &self.component.protocol_system, &self.tokens, &self.price]
     }
 }
 
@@ -284,7 +284,7 @@ impl App {
             .add_modifier(Modifier::REVERSED)
             .fg(self.colors.selected_cell_style_fg);
 
-        let header = ["Pool", "Tokens", "Price"]
+        let header = ["Pool", "Protocol", "Tokens", "Price"]
             .into_iter()
             .map(Cell::from)
             .collect::<Row>()
@@ -316,6 +316,7 @@ impl App {
             [
                 // + 1 is for padding.
                 Constraint::Length(43),
+                Constraint::Min(1),
                 Constraint::Min(1),
                 Constraint::Min(1),
             ],

--- a/examples/quickstart/main.rs
+++ b/examples/quickstart/main.rs
@@ -161,7 +161,8 @@ async fn main() {
     )
     .expect("Failed to private key signer");
     let tx_signer = EthereumWallet::from(wallet.clone());
-    let named_chain = NamedChain::from_str(&cli.chain).expect("Invalid chain");
+    let named_chain =
+        NamedChain::from_str(&cli.chain.replace("ethereum", "mainnet")).expect("Invalid chain");
     let provider = ProviderBuilder::new()
         .with_chain(named_chain)
         .wallet(tx_signer.clone())


### PR DESCRIPTION
This PR adds the protocol name for each protocol component in the price printer example.

It also fixes a small bug in the quickstart example.