### PR TITLE
fix: miscellaneous fixes in the price printer example and evm Tycho decoder

### DIFF
--- a/examples/price_printer/ui.rs
+++ b/examples/price_printer/ui.rs
@@ -133,7 +133,10 @@ impl App {
             if decimals >= prev_decimals {
                 self.quote_amount *= BigUint::from(10u64).pow((decimals - prev_decimals) as u32);
             } else {
-                self.quote_amount /= BigUint::from(10u64).pow((prev_decimals - decimals) as u32);
+                let new_amount = self.quote_amount.clone() /
+                    BigUint::from(10u64).pow((prev_decimals - decimals) as u32);
+                self.quote_amount =
+                    if new_amount > BigUint::ZERO { new_amount } else { BigUint::one() };
             }
         }
     }


### PR DESCRIPTION
This PR fixes two bugs: 

1. In the price printer example it fixes a bug where the amount would become 0 if there was a negative decimals difference between previous and current token in
2. In the Tycho decoder it fixes a bug where wrong insertions were made into the `contracts_map` leading to panics
