### PR TITLE
refactor: make protocol state fields public to access state data directly via ProtocolStreamBuilder

### DIFF
--- a/src/evm/protocol/uniswap_v3/state.rs
+++ b/src/evm/protocol/uniswap_v3/state.rs
@@ -32,11 +32,11 @@ use crate::{
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UniswapV3State {
-    liquidity: u128,
-    sqrt_price: U256,
-    fee: FeeAmount,
-    tick: i32,
-    ticks: TickList,
+    pub liquidity: u128,
+    pub sqrt_price: U256,
+    pub fee: FeeAmount,
+    pub tick: i32,
+    pub ticks: TickList,
 }
 
 impl UniswapV3State {

--- a/src/evm/protocol/uniswap_v4/state.rs
+++ b/src/evm/protocol/uniswap_v4/state.rs
@@ -31,21 +31,21 @@ use crate::{
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UniswapV4State {
-    liquidity: u128,
-    sqrt_price: U256,
-    fees: UniswapV4Fees,
-    tick: i32,
-    ticks: TickList,
+    pub liquidity: u128,
+    pub sqrt_price: U256,
+    pub fees: UniswapV4Fees,
+    pub tick: i32,
+    pub ticks: TickList,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UniswapV4Fees {
     // Protocol fees in the zero for one direction
-    zero_for_one: u32,
+    pub zero_for_one: u32,
     // Protocol fees in the one for zero direction
-    one_for_zero: u32,
+    pub one_for_zero: u32,
     // Liquidity providers fees
-    lp_fee: u32,
+    pub lp_fee: u32,
 }
 
 impl UniswapV4Fees {

--- a/src/evm/protocol/utils/uniswap/tick_list.rs
+++ b/src/evm/protocol/utils/uniswap/tick_list.rs
@@ -6,9 +6,9 @@ use super::tick_math;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct TickInfo {
-    pub(crate) index: i32,
-    pub(crate) net_liquidity: i128,
-    pub(crate) sqrt_price: U256,
+    pub index: i32,
+    pub net_liquidity: i128,
+    pub sqrt_price: U256,
 }
 
 impl TickInfo {
@@ -40,9 +40,9 @@ pub(crate) enum TickListErrorKind {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct TickList {
-    tick_spacing: u16,
-    ticks: Vec<TickInfo>,
+pub struct TickList {
+    pub tick_spacing: u16,
+    pub ticks: Vec<TickInfo>,
 }
 
 impl TickList {

--- a/src/evm/protocol/vm/state.rs
+++ b/src/evm/protocol/vm/state.rs
@@ -41,13 +41,13 @@ where
     <D as EngineDatabaseInterface>::Error: Debug,
 {
     /// The pool's identifier
-    id: String,
+    pub id: String,
     /// The pool's token's addresses
     pub tokens: Vec<Bytes>,
     /// The current block, will be used to set vm context
-    block: BlockHeader,
+    pub block: BlockHeader,
     /// The pool's token balances
-    balances: HashMap<Address, U256>,
+    pub balances: HashMap<Address, U256>,
     /// The contract address for where protocol balances are stored (i.e. a vault contract).
     /// If given, balances will be overwritten here instead of on the pool contract during
     /// simulations
@@ -55,7 +55,7 @@ where
     /// Spot prices of the pool by token pair
     spot_prices: HashMap<(Address, Address), f64>,
     /// The supported capabilities of this pool
-    capabilities: HashSet<Capability>,
+    pub capabilities: HashSet<Capability>,
     /// Storage overwrites that will be applied to all simulations. They will be cleared
     /// when ``clear_all_cache`` is called, i.e. usually at each block. Hence, the name.
     block_lasting_overwrites: HashMap<Address, Overwrites>,


### PR DESCRIPTION
Access to the internal field of protocol state structures is currently impossible when they are streamed by ProtocolStreamBuilder (although TychoStreamBuilder allows it).

The ProtocolStreamBuilder streams a BlockUpdate structure containing protocol states, each of which can be converted into a specific protocol state (UniswapV3State, etc.).

This PR changes the state structure fields from internal to public, which means that the attributes (liquidity ticks, etc.) can be read. Subject also mentioned in Tycho Telegram.

