### PR TITLE
chore: Checkout CI target branch.

### DIFF
--- a/.github/workflows/tests-and-lints-template.yaml
+++ b/.github/workflows/tests-and-lints-template.yaml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup git to use https
         run: |


### PR DESCRIPTION
We started using pull_request_target event so forks can properly run the CI. But that leads to the checkout being on main which is obviously not helpful.

With this change we checkout the target branch before running the tests.

See this issue for more information:

https://github.com/actions/checkout/issues/518