### PR TITLE
feat: update tycho-execution version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7886,8 +7886,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.64.0"
-source = "git+https://github.com/propeller-heads/tycho-execution.git?tag=0.64.0#d7244ada8c002ff0a5b9a064eb0b380dd2d567b5"
+version = "0.66.1"
+source = "git+https://github.com/propeller-heads/tycho-execution.git?tag=0.66.1#5a6433caf1e968ed972bd510c0b87698b65bce14"
 dependencies = [
  "alloy 0.9.2",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ lazy_static = "1.4.0"
 # Tycho dependencies
 tycho-core = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-core", tag = "0.61.1" }
 tycho-client = { git = "https://github.com/propeller-heads/tycho-indexer.git", package = "tycho-client", tag = "0.61.1" }
-tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution.git", package = "tycho-execution", features = ["evm"], tag = "0.64.0" }
+tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution.git", package = "tycho-execution", features = ["evm"], tag = "0.66.1" }
 
 # EVM dependencies
 foundry-config = { git = "https://github.com/foundry-rs/foundry", rev = "57bb12e", optional = true }


### PR DESCRIPTION
- This update is needed to fix a slippage issue where 0.1% would be rounded to 0
- The latest tycho-execution also supports cyclical swaps, although this new feature isn't needed in the latest quickstart