### PR TITLE
feat: add Unichain support in price printer

### DIFF
--- a/examples/price_printer/main.rs
+++ b/examples/price_printer/main.rs
@@ -72,6 +72,16 @@ fn register_exchanges(
                     Some(uniswap_v4_pool_with_hook_filter),
                 )
         }
+        Chain::Unichain => {
+            builder = builder
+                .exchange::<UniswapV2State>("uniswap_v2", tvl_filter.clone(), None)
+                .exchange::<UniswapV3State>("uniswap_v3", tvl_filter.clone(), None)
+                .exchange::<UniswapV4State>(
+                    "uniswap_v4",
+                    tvl_filter.clone(),
+                    Some(uniswap_v4_pool_with_hook_filter),
+                )
+        }
         _ => {}
     }
     builder

--- a/examples/price_printer/utils.rs
+++ b/examples/price_printer/utils.rs
@@ -16,6 +16,7 @@ pub(super) fn get_default_url(chain: &Chain) -> Option<String> {
     match chain {
         Chain::Ethereum => Some("tycho-beta.propellerheads.xyz".to_string()),
         Chain::Base => Some("tycho-base-beta.propellerheads.xyz".to_string()),
+        Chain::Unichain => Some("tycho-unichain-beta.propellerheads.xyz".to_string()),
         _ => None,
     }
 }


### PR DESCRIPTION
- Updated `register_exchanges` to include Uniswap exchanges for Unichain.
- Added default URL for Unichain in `get_default_url` function.