### PR TITLE
refactor: improvemenets to quickstart

### DIFF
--- a/examples/quickstart/utils.rs
+++ b/examples/quickstart/utils.rs
@@ -1,0 +1,10 @@
+use tycho_common::models::Chain;
+
+pub(super) fn get_default_url(chain: &Chain) -> Option<String> {
+    match chain {
+        Chain::Ethereum => Some("tycho-beta.propellerheads.xyz".to_string()),
+        Chain::Base => Some("tycho-base-beta.propellerheads.xyz".to_string()),
+        Chain::Unichain => Some("tycho-unichain-beta.propellerheads.xyz".to_string()),
+        _ => None,
+    }
+}


### PR DESCRIPTION
- These improvements were copied over from the price printer. After this, we will be able to swap on more protocols if ethereum chain is chosen (sushiv2, pancakev2, pancakev3, balancer, ekubo). Before, we were restricting ourselves to protocols that were available on all chains.
- It also fetches the correct tycho default URL depending on chain.