### PR TITLE
refactor: make protocol state fields public

### DIFF
--- a/src/evm/protocol/uniswap_v3/state.rs
+++ b/src/evm/protocol/uniswap_v3/state.rs
@@ -33,11 +33,11 @@ use crate::{
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UniswapV3State {
-    liquidity: u128,
-    sqrt_price: U256,
-    fee: FeeAmount,
-    tick: i32,
-    ticks: TickList,
+    pub liquidity: u128,
+    pub sqrt_price: U256,
+    pub fee: FeeAmount,
+    pub tick: i32,
+    pub ticks: TickList,
 }
 
 impl UniswapV3State {
@@ -108,8 +108,8 @@ impl UniswapV3State {
         };
         let mut gas_used = U256::from(130_000);
 
-        while state.amount_remaining != I256::from_raw(U256::from(0u64)) &&
-            state.sqrt_price != price_limit
+        while state.amount_remaining != I256::from_raw(U256::from(0u64))
+            && state.sqrt_price != price_limit
         {
             let (mut next_tick, initialized) = match self
                 .ticks
@@ -227,8 +227,8 @@ impl ProtocolSim for UniswapV3State {
         if a < b {
             Ok(sqrt_price_q96_to_f64(self.sqrt_price, a.decimals as u32, b.decimals as u32))
         } else {
-            Ok(1.0f64 /
-                sqrt_price_q96_to_f64(self.sqrt_price, b.decimals as u32, a.decimals as u32))
+            Ok(1.0f64
+                / sqrt_price_q96_to_f64(self.sqrt_price, b.decimals as u32, a.decimals as u32))
         }
     }
 
@@ -457,11 +457,11 @@ impl ProtocolSim for UniswapV3State {
             .as_any()
             .downcast_ref::<UniswapV3State>()
         {
-            self.liquidity == other_state.liquidity &&
-                self.sqrt_price == other_state.sqrt_price &&
-                self.fee == other_state.fee &&
-                self.tick == other_state.tick &&
-                self.ticks == other_state.ticks
+            self.liquidity == other_state.liquidity
+                && self.sqrt_price == other_state.sqrt_price
+                && self.fee == other_state.fee
+                && self.tick == other_state.tick
+                && self.ticks == other_state.ticks
         } else {
             false
         }

--- a/src/evm/protocol/uniswap_v4/state.rs
+++ b/src/evm/protocol/uniswap_v4/state.rs
@@ -32,21 +32,21 @@ use crate::{
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UniswapV4State {
-    liquidity: u128,
-    sqrt_price: U256,
-    fees: UniswapV4Fees,
-    tick: i32,
-    ticks: TickList,
+    pub liquidity: u128,
+    pub sqrt_price: U256,
+    pub fees: UniswapV4Fees,
+    pub tick: i32,
+    pub ticks: TickList,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UniswapV4Fees {
     // Protocol fees in the zero for one direction
-    zero_for_one: u32,
+    pub zero_for_one: u32,
     // Protocol fees in the one for zero direction
-    one_for_zero: u32,
+    pub one_for_zero: u32,
     // Liquidity providers fees
-    lp_fee: u32,
+    pub lp_fee: u32,
 }
 
 impl UniswapV4Fees {
@@ -117,8 +117,8 @@ impl UniswapV4State {
         };
         let mut gas_used = U256::from(130_000);
 
-        while state.amount_remaining != I256::from_raw(U256::from(0u64)) &&
-            state.sqrt_price != price_limit
+        while state.amount_remaining != I256::from_raw(U256::from(0u64))
+            && state.sqrt_price != price_limit
         {
             let (mut next_tick, initialized) = match self
                 .ticks
@@ -239,8 +239,8 @@ impl ProtocolSim for UniswapV4State {
         if base < quote {
             Ok(sqrt_price_q96_to_f64(self.sqrt_price, base.decimals as u32, quote.decimals as u32))
         } else {
-            Ok(1.0f64 /
-                sqrt_price_q96_to_f64(
+            Ok(1.0f64
+                / sqrt_price_q96_to_f64(
                     self.sqrt_price,
                     quote.decimals as u32,
                     base.decimals as u32,
@@ -456,11 +456,11 @@ impl ProtocolSim for UniswapV4State {
             .as_any()
             .downcast_ref::<UniswapV4State>()
         {
-            self.liquidity == other_state.liquidity &&
-                self.sqrt_price == other_state.sqrt_price &&
-                self.fees == other_state.fees &&
-                self.tick == other_state.tick &&
-                self.ticks == other_state.ticks
+            self.liquidity == other_state.liquidity
+                && self.sqrt_price == other_state.sqrt_price
+                && self.fees == other_state.fees
+                && self.tick == other_state.tick
+                && self.ticks == other_state.ticks
         } else {
             false
         }

--- a/src/evm/protocol/utils/uniswap/tick_list.rs
+++ b/src/evm/protocol/utils/uniswap/tick_list.rs
@@ -6,9 +6,9 @@ use super::tick_math::{self, MAX_TICK, MIN_TICK};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct TickInfo {
-    pub(crate) index: i32,
-    pub(crate) net_liquidity: i128,
-    pub(crate) sqrt_price: U256,
+    pub index: i32,
+    pub net_liquidity: i128,
+    pub sqrt_price: U256,
 }
 
 impl TickInfo {
@@ -41,8 +41,8 @@ pub(crate) enum TickListErrorKind {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct TickList {
-    tick_spacing: u16,
-    ticks: Vec<TickInfo>,
+    pub tick_spacing: u16,
+    pub ticks: Vec<TickInfo>,
 }
 
 impl TickList {

--- a/src/evm/protocol/utils/uniswap/tick_list.rs
+++ b/src/evm/protocol/utils/uniswap/tick_list.rs
@@ -40,7 +40,7 @@ pub(crate) enum TickListErrorKind {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct TickList {
+pub struct TickList {
     pub tick_spacing: u16,
     pub ticks: Vec<TickInfo>,
 }

--- a/src/evm/protocol/vm/state.rs
+++ b/src/evm/protocol/vm/state.rs
@@ -46,18 +46,18 @@ where
     /// The pool's token's addresses
     pub tokens: Vec<Bytes>,
     /// The current block, will be used to set vm context
-    block: BlockHeader,
+    pub block: BlockHeader,
     /// The pool's component balances.
-    balances: HashMap<Address, U256>,
+    pub balances: HashMap<Address, U256>,
     /// The contract address for where protocol balances are stored (i.e. a vault contract).
     /// If given, balances will be overwritten here instead of on the pool contract during
     /// simulations. This has been deprecated in favor of `contract_balances`.
     #[deprecated(note = "Use contract_balances instead")]
     balance_owner: Option<Address>,
     /// Spot prices of the pool by token pair
-    spot_prices: HashMap<(Address, Address), f64>,
+    pub spot_prices: HashMap<(Address, Address), f64>,
     /// The supported capabilities of this pool
-    capabilities: HashSet<Capability>,
+    pub capabilities: HashSet<Capability>,
     /// Storage overwrites that will be applied to all simulations. They will be cleared
     /// when ``update_pool_state`` is called, i.e. usually at each block. Hence, the name.
     block_lasting_overwrites: HashMap<Address, Overwrites>,
@@ -219,8 +219,8 @@ where
                 })?;
                 let sell_token_decimals = self.get_decimals(tokens, &sell_token_address)?;
                 let buy_token_decimals = self.get_decimals(tokens, &buy_token_address)?;
-                *unscaled_price * 10f64.powi(sell_token_decimals as i32) /
-                    10f64.powi(buy_token_decimals as i32)
+                *unscaled_price * 10f64.powi(sell_token_decimals as i32)
+                    / 10f64.powi(buy_token_decimals as i32)
             };
 
             self.spot_prices
@@ -541,8 +541,8 @@ where
         )?;
         let (sell_amount_respecting_limit, sell_amount_exceeds_limit) = if self
             .capabilities
-            .contains(&Capability::HardLimits) &&
-            sell_amount_limit < sell_amount
+            .contains(&Capability::HardLimits)
+            && sell_amount_limit < sell_amount
         {
             (sell_amount_limit, true)
         } else {


### PR DESCRIPTION
Access to the internal field of protocol state structures is currently impossible when they are streamed by ProtocolStreamBuilder. This PR changes the state structure fields from internal to public.