### PR TITLE
fix(simulation): fix balances overwrites bugs

### DIFF
--- a/examples/price_printer/Readme.md
+++ b/examples/price_printer/Readme.md
@@ -7,5 +7,5 @@ quotes from each pool.
 
 ```bash
 export RPC_URL=<your-node-rpc-url>
-cargo run --release --example price_printer -- --tvl-threshold 1000 --chain <ethereum | base>
+cargo run --release --example price_printer -- --tvl-threshold 1000 --chain <ethereum | base | unichain>
 ```

--- a/examples/price_printer/main.rs
+++ b/examples/price_printer/main.rs
@@ -13,6 +13,7 @@ use tycho_simulation::{
     evm::{
         engine_db::tycho_db::PreCachedDB,
         protocol::{
+            ekubo::state::EkuboState,
             filters::{balancer_pool_filter, curve_pool_filter, uniswap_v4_pool_with_hook_filter},
             uniswap_v2::state::UniswapV2State,
             uniswap_v3::state::UniswapV3State,
@@ -56,6 +57,7 @@ fn register_exchanges(
                     tvl_filter.clone(),
                     Some(curve_pool_filter),
                 )
+                .exchange::<EkuboState>("ekubo_v2", tvl_filter.clone(), None)
                 .exchange::<UniswapV4State>(
                     "uniswap_v4",
                     tvl_filter.clone(),

--- a/src/evm/decoder.rs
+++ b/src/evm/decoder.rs
@@ -248,9 +248,12 @@ impl TychoStreamDecoder {
                 .snapshots
                 .get_vm_storage()
                 .iter()
-                .map(|(addr, acc)| {
+                .filter_map(|(addr, acc)| {
                     let balances = acc.token_balances.clone();
-                    (addr.clone(), balances)
+                    if balances.is_empty() {
+                        return None;
+                    }
+                    Some((addr.clone(), balances))
                 })
                 .collect::<AccountBalances>();
             info!("Updating engine with {} snapshots", storage_by_address.len());

--- a/src/evm/protocol/vm/state.rs
+++ b/src/evm/protocol/vm/state.rs
@@ -305,18 +305,16 @@ where
                 .component_balances
                 .get(&self.id)
             {
-                self.balances = bals
-                    .iter()
-                    .map(|(token, bal)| {
-                        let addr = bytes_to_address(token).map_err(|_| {
-                            SimulationError::FatalError(format!(
-                                "Invalid token address in balance update: {:?}",
-                                token
-                            ))
-                        })?;
-                        Ok((addr, U256::from_be_slice(bal)))
-                    })
-                    .collect::<Result<HashMap<_, _>, SimulationError>>()?;
+                for (token, bal) in bals {
+                    let addr = bytes_to_address(token).map_err(|_| {
+                        SimulationError::FatalError(format!(
+                            "Invalid token address in balance update: {:?}",
+                            token
+                        ))
+                    })?;
+                    self.balances
+                        .insert(addr, U256::from_be_slice(bal));
+                }
             }
         } else {
             // Pool uses contract balances for overwrites


### PR DESCRIPTION
This PR fixes two bugs in the balance overwrites:

- We were using account-balances even when they were empty
- We were deleting some useful balances on updates for >2 tokens pools

Also added EkuboV2 in the price printer and updated the readme for Unichain support