### PR TITLE
fix: Extend curve filter to filter out currently unsupported pools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8144,9 +8144,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.79.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de52f1813c54e11166d6b446dd66d070aa8ea43dcca7f8781a11b99ed428a12c"
+checksum = "0d4cab66503c0031c3a0a24bcc618ee3a99967423534ea0fa4a1e49adecf4eb1"
 dependencies = [
  "alloy 0.9.2",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ ratatui = "0.29.0"
 crossterm = { version = "0.28.1", features = ["event-stream"] }
 unicode-width = "0.1.13"
 tracing-appender = "0.2.3"
-tycho-execution = "0.79.0"
+tycho-execution = "0.80.0"
 
 [features]
 default = ["evm"]

--- a/src/evm/protocol/filters.rs
+++ b/src/evm/protocol/filters.rs
@@ -139,7 +139,10 @@ pub fn curve_pool_filter(component: &ComponentWithState) -> bool {
     };
 
     if component.component.id.to_lowercase() == "0xdc24316b9ae028f1497c275eb9192a3ea0f67022" {
-        info!("Filtering out Curve pool {} because it is not supported", component.component.id);
+        info!(
+            "Filtering out Curve pool {} because it has a rebasing token that is not supported",
+            component.component.id
+        );
         return false
     }
 

--- a/src/evm/protocol/filters.rs
+++ b/src/evm/protocol/filters.rs
@@ -123,6 +123,26 @@ pub fn curve_pool_filter(component: &ComponentWithState) -> bool {
             return false;
         }
     }
+    if let Some(factory_attribute) = component
+        .component
+        .static_attributes
+        .get("factory")
+    {
+        let factory = std::str::from_utf8(factory_attribute).expect("Invalid UTF-8 data");
+        if factory.to_lowercase() == "0xf18056bbd320e96a48e3fbf8bc061322531aac99" {
+            info!(
+                "Filtering out Curve pool {} because it belongs to an unsupported factory",
+                component.component.id
+            );
+            return false
+        }
+    };
+
+    if component.component.id.to_lowercase() == "0xdc24316b9ae028f1497c275eb9192a3ea0f67022" {
+        info!("Filtering out Curve pool {} because it is not supported", component.component.id);
+        return false
+    }
+
     true
 }
 

--- a/src/evm/stream.rs
+++ b/src/evm/stream.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use futures::{Stream, StreamExt};
 use tokio_stream::wrappers::ReceiverStream;
+use tracing::warn;
 use tycho_client::{
     feed::{component_tracker::ComponentFilter, synchronizer::ComponentWithState},
     stream::{StreamError, TychoStreamBuilder},
@@ -83,6 +84,11 @@ impl ProtocolStreamBuilder {
             self.decoder
                 .register_filter(name, predicate);
         }
+
+        if ["uniswap_v4", "vm:balancer_v2", "vm:curve"].contains(&name) && filter_fn.is_none() {
+            warn!("Warning: For exchange type '{}', it is necessary to set a filter function because not all pools are supported. See all filters at src/evm/protocol/filters.rs", name);
+        }
+
         self
     }
 


### PR DESCRIPTION
Simulation for these pools is not correct at the moment.

Add warning if filter is not set for uniswap_v4, balancer_v2 and curve
