### PR TITLE
fix: update curve_pool_filter to exclude additional stETH bugged pool

### DIFF
--- a/src/evm/protocol/filters.rs
+++ b/src/evm/protocol/filters.rs
@@ -132,13 +132,17 @@ pub fn curve_pool_filter(component: &ComponentWithState) -> bool {
         }
     };
 
-    if matches!(
-        component
+    // Curve pools with rebasing tokens that are not supported
+    const UNSUPPORTED_REBASING_COMPONENT_IDS: [&str; 2] = [
+        "0xdc24316b9ae028f1497c275eb9192a3ea0f67022",
+        "0x828b154032950c8ff7cf8085d841723db2696056",
+    ];
+    if UNSUPPORTED_REBASING_COMPONENT_IDS.contains(
+        &component
             .component
             .id
             .to_lowercase()
             .as_str(),
-        "0xdc24316b9ae028f1497c275eb9192a3ea0f67022" | "0x828b154032950c8ff7cf8085d841723db2696056"
     ) {
         debug!(
             "Filtering out Curve pool {} because it has a rebasing token that is not supported",

--- a/src/evm/protocol/filters.rs
+++ b/src/evm/protocol/filters.rs
@@ -132,7 +132,14 @@ pub fn curve_pool_filter(component: &ComponentWithState) -> bool {
         }
     };
 
-    if component.component.id.to_lowercase() == "0xdc24316b9ae028f1497c275eb9192a3ea0f67022" {
+    if matches!(
+        component
+            .component
+            .id
+            .to_lowercase()
+            .as_str(),
+        "0xdc24316b9ae028f1497c275eb9192a3ea0f67022" | "0x828b154032950c8ff7cf8085d841723db2696056"
+    ) {
         debug!(
             "Filtering out Curve pool {} because it has a rebasing token that is not supported",
             component.component.id


### PR DESCRIPTION
This pool suffers from the same issue, its stETH indexed balances are wrong because we only account for transfered tokens and not rebasing. This then leads to bugs during simulations.