### PR TITLE
feat: Add initial draft for RFQs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4247,6 +4247,19 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
@@ -6223,10 +6236,12 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.32",
  "hyper-rustls 0.24.2",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -6238,6 +6253,7 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "system-configuration 0.5.1",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.24.1",
  "tower-service",
  "url",
@@ -6267,7 +6283,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "hyper-rustls 0.27.5",
- "hyper-tls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -8175,6 +8191,7 @@ dependencies = [
  "alloy-sol-types",
  "anyhow",
  "approx",
+ "async-trait",
  "chrono",
  "clap",
  "crossterm",
@@ -8193,6 +8210,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "ratatui",
+ "reqwest 0.11.27",
  "revm",
  "revm-inspectors",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,8 @@ dialoguer = "0.10.4"
 
 # Ekubo
 evm_ekubo_sdk = "0.4.0"
+async-trait = "0.1.88"
+reqwest = "0.11.27"
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/examples/price_printer/main.rs
+++ b/examples/price_printer/main.rs
@@ -22,7 +22,7 @@ use tycho_simulation::{
         },
         stream::ProtocolStreamBuilder,
     },
-    protocol::models::BlockUpdate,
+    protocol::models::Update,
     utils::load_all_tokens,
 };
 use utils::get_default_url;
@@ -110,7 +110,7 @@ async fn main() {
     env::var("RPC_URL").expect("RPC_URL env variable should be set");
 
     // Create communication channels for inter-thread communication
-    let (tick_tx, tick_rx) = mpsc::channel::<BlockUpdate>(12);
+    let (tick_tx, tick_rx) = mpsc::channel::<Update>(12);
 
     let tycho_message_processor: JoinHandle<anyhow::Result<()>> = tokio::spawn(async move {
         let all_tokens = load_all_tokens(

--- a/examples/price_printer/ui.rs
+++ b/examples/price_printer/ui.rs
@@ -19,7 +19,7 @@ use tokio::{select, sync::mpsc::Receiver};
 use tracing::warn;
 use tycho_common::Bytes;
 use tycho_simulation::protocol::{
-    models::{BlockUpdate, ProtocolComponent},
+    models::{ProtocolComponent, Update},
     state::ProtocolSim,
 };
 
@@ -80,13 +80,13 @@ pub struct App {
     quote_amount: BigUint,
     zero2one: bool,
     items: Vec<Data>,
-    rx: Receiver<BlockUpdate>,
+    rx: Receiver<Update>,
     scroll_state: ScrollbarState,
     colors: TableColors,
 }
 
 impl App {
-    pub fn new(rx: Receiver<BlockUpdate>) -> Self {
+    pub fn new(rx: Receiver<Update>) -> Self {
         let data_vec = Vec::new();
         Self {
             state: TableState::default().with_selected(0),
@@ -141,7 +141,7 @@ impl App {
         }
     }
 
-    pub fn update_data(&mut self, update: BlockUpdate) {
+    pub fn update_data(&mut self, update: Update) {
         for (id, comp) in update.new_pairs.iter() {
             let name = format!("{comp_id:#042x}", comp_id = comp.id);
             let tokens = comp

--- a/examples/quickstart/main.rs
+++ b/examples/quickstart/main.rs
@@ -53,7 +53,7 @@ use tycho_simulation::{
         stream::ProtocolStreamBuilder,
     },
     models::Token,
-    protocol::models::{BlockUpdate, ProtocolComponent},
+    protocol::models::{ProtocolComponent, Update},
     tycho_client::feed::component_tracker::ComponentFilter,
     tycho_common::models::Chain,
     utils::load_all_tokens,
@@ -508,7 +508,7 @@ async fn main() {
 }
 
 fn get_best_swap(
-    message: BlockUpdate,
+    message: Update,
     pairs: &mut HashMap<String, ProtocolComponent>,
     amount_in: BigUint,
     sell_token: Token,

--- a/src/evm/decoder.rs
+++ b/src/evm/decoder.rs
@@ -21,7 +21,7 @@ use crate::{
     models::{Balances, Token},
     protocol::{
         errors::InvalidSnapshotError,
-        models::{BlockUpdate, ProtocolComponent, TryFromWithBlock},
+        models::{ProtocolComponent, TryFromWithBlock, Update},
         state::ProtocolSim,
     },
 };
@@ -149,7 +149,7 @@ impl TychoStreamDecoder {
 
     /// Decodes a `FeedMessage` into a `BlockUpdate` containing the updated states of protocol
     /// components
-    pub async fn decode(&self, msg: FeedMessage) -> Result<BlockUpdate, StreamDecodeError> {
+    pub async fn decode(&self, msg: FeedMessage) -> Result<Update, StreamDecodeError> {
         // stores all states updated in this tick/msg
         let mut updated_states = HashMap::new();
         let mut new_pairs = HashMap::new();
@@ -465,8 +465,7 @@ impl TychoStreamDecoder {
         }
 
         // Send the tick with all updated states
-        Ok(BlockUpdate::new(block.number, updated_states, new_pairs)
-            .set_removed_pairs(removed_pairs))
+        Ok(Update::new(block.number, updated_states, new_pairs).set_removed_pairs(removed_pairs))
     }
 
     fn apply_update(

--- a/src/evm/protocol/mod.rs
+++ b/src/evm/protocol/mod.rs
@@ -10,3 +10,4 @@ pub mod utils;
 pub mod vm;
 
 mod cpmm;
+mod rfq;

--- a/src/evm/protocol/rfq/client.rs
+++ b/src/evm/protocol/rfq/client.rs
@@ -11,7 +11,8 @@ pub trait RFQClient: Send + Sync {
     // IndicativePrice
     async fn next_price_update(&mut self) -> Result<Vec<Box<dyn PriceEstimator>>, RFQError>;
 
-    // This method is responsible for fetching the binding quote from the RFQ API
+    // This method is responsible for fetching the binding quote from the RFQ API. Use sender and
+    // receiver from GetAmountOutParams to ask for the quote
     async fn request_binding_quote(
         &self,
         params: &GetAmountOutParams,

--- a/src/evm/protocol/rfq/client.rs
+++ b/src/evm/protocol/rfq/client.rs
@@ -1,7 +1,4 @@
-use std::pin::Pin;
-
 use async_trait::async_trait;
-use futures::{Stream, StreamExt};
 
 use crate::{
     evm::protocol::rfq::{indicative_price::IndicativePrice, state::BindingQuote},
@@ -20,80 +17,4 @@ pub trait RFQClientSource: Send + Sync {
     ) -> Result<BindingQuote, SimulationError>;
 
     fn clone_box(&self) -> Box<dyn RFQClientSource>;
-}
-
-#[async_trait]
-pub trait IndicativePriceSource: Send + Sync {
-    async fn next_price_update(&mut self)
-        -> Result<Vec<Box<dyn IndicativePrice>>, SimulationError>;
-}
-
-pub struct HttpPricePoller<P: IndicativePrice + for<'de> serde::Deserialize<'de> + 'static> {
-    http: reqwest::Client,
-    endpoint: String,
-    _phantom: std::marker::PhantomData<P>,
-}
-
-impl<P: IndicativePrice + for<'de> serde::Deserialize<'de> + 'static> HttpPricePoller<P> {
-    pub fn new(endpoint: String) -> Self {
-        Self { http: reqwest::Client::new(), endpoint, _phantom: std::marker::PhantomData }
-    }
-}
-
-#[async_trait]
-impl<P> IndicativePriceSource for HttpPricePoller<P>
-where
-    P: IndicativePrice + for<'de> serde::Deserialize<'de> + Send + Sync + 'static,
-{
-    async fn next_price_update(
-        &mut self,
-    ) -> Result<Vec<Box<dyn IndicativePrice>>, SimulationError> {
-        let res = self
-            .http
-            .get(&self.endpoint)
-            .send()
-            .await?;
-        let parsed = res.json::<P>().await?; // this shouldn't be so easy. as of now the IndicativePrice is for 1 token pair. I think we
-                                             // will need some new structure to define the whole msg structure for each RFQ
-        Ok(vec![Box::new(parsed)])
-    }
-}
-
-pub struct SyncStream<P>(Pin<Box<dyn Stream<Item = P> + Send + Sync>>);
-
-impl<P> Stream for SyncStream<P> {
-    type Item = P;
-
-    fn poll_next(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        self.0.as_mut().poll_next(cx)
-    }
-}
-
-pub struct WebSocketPriceStream<P: IndicativePrice + 'static> {
-    stream: SyncStream<P>,
-}
-
-impl<P: IndicativePrice + 'static> WebSocketPriceStream<P> {
-    pub fn new(stream: Pin<Box<dyn Stream<Item = P> + Send + Sync>>) -> Self {
-        Self { stream: SyncStream(stream) }
-    }
-}
-
-#[async_trait]
-impl<P> IndicativePriceSource for WebSocketPriceStream<P>
-where
-    P: IndicativePrice + Send + Sync + 'static,
-{
-    async fn next_price_update(
-        &mut self,
-    ) -> Result<Vec<Box<dyn IndicativePrice>>, SimulationError> {
-        if let Some(update) = self.stream.next().await {
-            Ok(vec![Box::new(update)])
-        } else {
-            Err(SimulationError::RecoverableError("WebSocket closed".into()))
-        }
-    }
 }

--- a/src/evm/protocol/rfq/client.rs
+++ b/src/evm/protocol/rfq/client.rs
@@ -1,23 +1,21 @@
 use async_trait::async_trait;
 
 use crate::{
-    evm::protocol::rfq::{
-        errors::RFQError, indicative_price::IndicativePrice, state::BindingQuote,
-    },
+    evm::protocol::rfq::{errors::RFQError, price_estimator::PriceEstimator, state::SignedQuote},
     models::GetAmountOutParams,
 };
 
 #[async_trait]
-pub trait RFQClientSource: Send + Sync {
+pub trait RFQClient: Send + Sync {
     // This method is responsible for fetching data from the RFQ API and converting into an
     // IndicativePrice
-    async fn next_price_update(&mut self) -> Result<Vec<Box<dyn IndicativePrice>>, RFQError>;
+    async fn next_price_update(&mut self) -> Result<Vec<Box<dyn PriceEstimator>>, RFQError>;
 
     // This method is responsible for fetching the binding quote from the RFQ API
     async fn request_binding_quote(
         &self,
         params: &GetAmountOutParams,
-    ) -> Result<BindingQuote, RFQError>;
+    ) -> Result<SignedQuote, RFQError>;
 
-    fn clone_box(&self) -> Box<dyn RFQClientSource>;
+    fn clone_box(&self) -> Box<dyn RFQClient>;
 }

--- a/src/evm/protocol/rfq/client.rs
+++ b/src/evm/protocol/rfq/client.rs
@@ -1,0 +1,99 @@
+use std::pin::Pin;
+
+use async_trait::async_trait;
+use futures::{Stream, StreamExt};
+
+use crate::{
+    evm::protocol::rfq::{indicative_price::IndicativePrice, state::BindingQuote},
+    models::GetAmountOutParams,
+    protocol::errors::SimulationError,
+};
+
+#[async_trait]
+pub trait RFQClientSource: Send + Sync {
+    async fn next_price_update(&mut self)
+        -> Result<Vec<Box<dyn IndicativePrice>>, SimulationError>;
+
+    async fn request_binding_quote(
+        &self,
+        params: &GetAmountOutParams,
+    ) -> Result<BindingQuote, SimulationError>;
+
+    fn clone_box(&self) -> Box<dyn RFQClientSource>;
+}
+
+#[async_trait]
+pub trait IndicativePriceSource: Send + Sync {
+    async fn next_price_update(&mut self)
+        -> Result<Vec<Box<dyn IndicativePrice>>, SimulationError>;
+}
+
+pub struct HttpPricePoller<P: IndicativePrice + for<'de> serde::Deserialize<'de> + 'static> {
+    http: reqwest::Client,
+    endpoint: String,
+    _phantom: std::marker::PhantomData<P>,
+}
+
+impl<P: IndicativePrice + for<'de> serde::Deserialize<'de> + 'static> HttpPricePoller<P> {
+    pub fn new(endpoint: String) -> Self {
+        Self { http: reqwest::Client::new(), endpoint, _phantom: std::marker::PhantomData }
+    }
+}
+
+#[async_trait]
+impl<P> IndicativePriceSource for HttpPricePoller<P>
+where
+    P: IndicativePrice + for<'de> serde::Deserialize<'de> + Send + Sync + 'static,
+{
+    async fn next_price_update(
+        &mut self,
+    ) -> Result<Vec<Box<dyn IndicativePrice>>, SimulationError> {
+        let res = self
+            .http
+            .get(&self.endpoint)
+            .send()
+            .await?;
+        let parsed = res.json::<P>().await?; // this shouldn't be so easy. as of now the IndicativePrice is for 1 token pair. I think we
+                                             // will need some new structure to define the whole msg structure for each RFQ
+        Ok(vec![Box::new(parsed)])
+    }
+}
+
+pub struct SyncStream<P>(Pin<Box<dyn Stream<Item = P> + Send + Sync>>);
+
+impl<P> Stream for SyncStream<P> {
+    type Item = P;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.0.as_mut().poll_next(cx)
+    }
+}
+
+pub struct WebSocketPriceStream<P: IndicativePrice + 'static> {
+    stream: SyncStream<P>,
+}
+
+impl<P: IndicativePrice + 'static> WebSocketPriceStream<P> {
+    pub fn new(stream: Pin<Box<dyn Stream<Item = P> + Send + Sync>>) -> Self {
+        Self { stream: SyncStream(stream) }
+    }
+}
+
+#[async_trait]
+impl<P> IndicativePriceSource for WebSocketPriceStream<P>
+where
+    P: IndicativePrice + Send + Sync + 'static,
+{
+    async fn next_price_update(
+        &mut self,
+    ) -> Result<Vec<Box<dyn IndicativePrice>>, SimulationError> {
+        if let Some(update) = self.stream.next().await {
+            Ok(vec![Box::new(update)])
+        } else {
+            Err(SimulationError::RecoverableError("WebSocket closed".into()))
+        }
+    }
+}

--- a/src/evm/protocol/rfq/client.rs
+++ b/src/evm/protocol/rfq/client.rs
@@ -1,20 +1,23 @@
 use async_trait::async_trait;
 
 use crate::{
-    evm::protocol::rfq::{indicative_price::IndicativePrice, state::BindingQuote},
+    evm::protocol::rfq::{
+        errors::RFQError, indicative_price::IndicativePrice, state::BindingQuote,
+    },
     models::GetAmountOutParams,
-    protocol::errors::SimulationError,
 };
 
 #[async_trait]
 pub trait RFQClientSource: Send + Sync {
-    async fn next_price_update(&mut self)
-        -> Result<Vec<Box<dyn IndicativePrice>>, SimulationError>;
+    // This method is responsible for fetching data from the RFQ API and converting into an
+    // IndicativePrice
+    async fn next_price_update(&mut self) -> Result<Vec<Box<dyn IndicativePrice>>, RFQError>;
 
+    // This method is responsible for fetching the binding quote from the RFQ API
     async fn request_binding_quote(
         &self,
         params: &GetAmountOutParams,
-    ) -> Result<BindingQuote, SimulationError>;
+    ) -> Result<BindingQuote, RFQError>;
 
     fn clone_box(&self) -> Box<dyn RFQClientSource>;
 }

--- a/src/evm/protocol/rfq/errors.rs
+++ b/src/evm/protocol/rfq/errors.rs
@@ -1,0 +1,22 @@
+use thiserror::Error;
+
+use crate::protocol::errors::SimulationError;
+
+#[derive(Debug, Error)]
+pub enum RFQError {
+    #[error("RFQ connection error: {0}")]
+    ConnectionError(String),
+    #[error("RFQ parsing error: {0}")]
+    ParsingError(String),
+}
+impl From<reqwest::Error> for RFQError {
+    fn from(err: reqwest::Error) -> Self {
+        RFQError::ConnectionError(err.to_string())
+    }
+}
+
+impl From<RFQError> for SimulationError {
+    fn from(err: RFQError) -> Self {
+        SimulationError::FatalError(err.to_string())
+    }
+}

--- a/src/evm/protocol/rfq/indicative_price.rs
+++ b/src/evm/protocol/rfq/indicative_price.rs
@@ -1,15 +1,16 @@
 use crate::{
+    evm::protocol::rfq::errors::RFQError,
     models::{GetAmountOutParams, Token},
-    protocol::{errors::SimulationError, models::GetAmountOutResult},
+    protocol::models::GetAmountOutResult,
 };
 
+/// This trait defines the interface for an indicative price provider.
+/// It might hold price levels, order books, or any other data needed by the RFQ to compute the
+/// current price.
 pub trait IndicativePrice: Send + Sync {
     fn base_token(&self) -> &Token;
     fn quote_token(&self) -> &Token;
-    fn get_amount_out(
-        &self,
-        params: GetAmountOutParams,
-    ) -> Result<GetAmountOutResult, SimulationError>;
+    fn get_amount_out(&self, params: GetAmountOutParams) -> Result<GetAmountOutResult, RFQError>;
 
     fn spot_price(&self) -> f64;
 

--- a/src/evm/protocol/rfq/indicative_price.rs
+++ b/src/evm/protocol/rfq/indicative_price.rs
@@ -1,0 +1,15 @@
+use crate::{
+    models::{GetAmountOutParams, Token},
+    protocol::{errors::SimulationError, models::GetAmountOutResult},
+};
+
+pub trait IndicativePrice: Send + Sync {
+    fn base_token(&self) -> &Token;
+    fn quote_token(&self) -> &Token;
+    fn get_amount_out(
+        &self,
+        params: GetAmountOutParams,
+    ) -> Result<GetAmountOutResult, SimulationError>;
+
+    fn clone_box(&self) -> Box<dyn IndicativePrice>;
+}

--- a/src/evm/protocol/rfq/indicative_price.rs
+++ b/src/evm/protocol/rfq/indicative_price.rs
@@ -11,5 +11,7 @@ pub trait IndicativePrice: Send + Sync {
         params: GetAmountOutParams,
     ) -> Result<GetAmountOutResult, SimulationError>;
 
+    fn spot_price(&self) -> f64;
+
     fn clone_box(&self) -> Box<dyn IndicativePrice>;
 }

--- a/src/evm/protocol/rfq/mod.rs
+++ b/src/evm/protocol/rfq/mod.rs
@@ -1,0 +1,5 @@
+mod client;
+mod indicative_price;
+mod protocols;
+pub mod state;
+mod stream;

--- a/src/evm/protocol/rfq/mod.rs
+++ b/src/evm/protocol/rfq/mod.rs
@@ -1,6 +1,6 @@
 mod client;
 mod errors;
-mod indicative_price;
+mod price_estimator;
 mod protocols;
 pub mod state;
 mod stream;

--- a/src/evm/protocol/rfq/mod.rs
+++ b/src/evm/protocol/rfq/mod.rs
@@ -1,4 +1,5 @@
 mod client;
+mod errors;
 mod indicative_price;
 mod protocols;
 pub mod state;

--- a/src/evm/protocol/rfq/price_estimator.rs
+++ b/src/evm/protocol/rfq/price_estimator.rs
@@ -7,6 +7,7 @@ use crate::{
 /// It might hold price levels, order books, or any other data needed by the RFQ to compute the
 /// current price.
 pub trait PriceEstimator: Send + Sync {
+    fn id(&self) -> String;
     fn base_token(&self) -> &String;
     fn quote_token(&self) -> &String;
     fn get_amount_out(&self, params: GetAmountOutParams) -> Result<GetAmountOutResult, RFQError>;

--- a/src/evm/protocol/rfq/price_estimator.rs
+++ b/src/evm/protocol/rfq/price_estimator.rs
@@ -1,6 +1,5 @@
 use crate::{
-    evm::protocol::rfq::errors::RFQError,
-    models::{GetAmountOutParams, Token},
+    evm::protocol::rfq::errors::RFQError, models::GetAmountOutParams,
     protocol::models::GetAmountOutResult,
 };
 
@@ -8,8 +7,8 @@ use crate::{
 /// It might hold price levels, order books, or any other data needed by the RFQ to compute the
 /// current price.
 pub trait PriceEstimator: Send + Sync {
-    fn base_token(&self) -> &Token;
-    fn quote_token(&self) -> &Token;
+    fn base_token(&self) -> &String;
+    fn quote_token(&self) -> &String;
     fn get_amount_out(&self, params: GetAmountOutParams) -> Result<GetAmountOutResult, RFQError>;
 
     fn spot_price(&self) -> f64;

--- a/src/evm/protocol/rfq/price_estimator.rs
+++ b/src/evm/protocol/rfq/price_estimator.rs
@@ -4,15 +4,15 @@ use crate::{
     protocol::models::GetAmountOutResult,
 };
 
-/// This trait defines the interface for an indicative price provider.
+/// This trait defines the interface for a price estimator
 /// It might hold price levels, order books, or any other data needed by the RFQ to compute the
 /// current price.
-pub trait IndicativePrice: Send + Sync {
+pub trait PriceEstimator: Send + Sync {
     fn base_token(&self) -> &Token;
     fn quote_token(&self) -> &Token;
     fn get_amount_out(&self, params: GetAmountOutParams) -> Result<GetAmountOutResult, RFQError>;
 
     fn spot_price(&self) -> f64;
 
-    fn clone_box(&self) -> Box<dyn IndicativePrice>;
+    fn clone_box(&self) -> Box<dyn PriceEstimator>;
 }

--- a/src/evm/protocol/rfq/protocols/bebop.rs
+++ b/src/evm/protocol/rfq/protocols/bebop.rs
@@ -10,6 +10,7 @@ use crate::{
 
 #[derive(Clone, Debug)]
 pub struct BebopIndicativePrice {
+    pub maker: String,
     pub base_token: String,
     pub quote_token: String,
     pub bids: Vec<(f64, f64)>,
@@ -18,6 +19,9 @@ pub struct BebopIndicativePrice {
 
 #[async_trait]
 impl PriceEstimator for BebopIndicativePrice {
+    fn id(&self) -> String {
+        format!("bebop-{}-{} {}", self.maker, self.base_token, self.quote_token)
+    }
     fn base_token(&self) -> &String {
         &self.base_token
     }

--- a/src/evm/protocol/rfq/protocols/bebop.rs
+++ b/src/evm/protocol/rfq/protocols/bebop.rs
@@ -2,9 +2,7 @@ use async_trait::async_trait;
 
 use crate::{
     evm::protocol::rfq::{
-        client::{IndicativePriceSource, RFQClientSource, WebSocketPriceStream},
-        indicative_price::IndicativePrice,
-        state::BindingQuote,
+        client::RFQClientSource, indicative_price::IndicativePrice, state::BindingQuote,
     },
     models::{GetAmountOutParams, Token},
     protocol::{errors::SimulationError, models::GetAmountOutResult},
@@ -36,21 +34,23 @@ impl IndicativePrice for BebopIndicativePrice {
         todo!()
     }
 
+    fn spot_price(&self) -> f64 {
+        todo!()
+    }
+
     fn clone_box(&self) -> Box<dyn IndicativePrice> {
         Box::new(self.clone())
     }
 }
-
+#[derive(Clone)]
 pub struct BebopClient {
-    // Fields for HTTP client, API keys, etc.
-    price_source: WebSocketPriceStream<BebopIndicativePrice>,
+    url: String,
 }
 
 impl BebopClient {
-    pub fn new(price_source: WebSocketPriceStream<BebopIndicativePrice>) -> Self {
-        // TODO: figure out how to make a stream from the websocket
-        // let price_source = WebSocketPriceStream::new("wss://api.bebop.com/v1/price");
-        Self { price_source }
+    pub fn new() -> Self {
+        let url = "wss://api.bebop.com/v1/price".to_string();
+        Self { url }
     }
 }
 
@@ -59,22 +59,19 @@ impl RFQClientSource for BebopClient {
     async fn next_price_update(
         &mut self,
     ) -> Result<Vec<Box<dyn IndicativePrice>>, SimulationError> {
-        self.price_source
-            .next_price_update()
-            .await
+        // get price data from Bebop
+        todo!()
     }
 
     async fn request_binding_quote(
         &self,
         params: &GetAmountOutParams,
     ) -> Result<BindingQuote, SimulationError> {
-        // gte binding quote from Bebop
+        // get binding quote from Bebop
         todo!()
     }
 
     fn clone_box(&self) -> Box<dyn RFQClientSource> {
-        todo!()
-        //Box::new(self.clone())
-        // this is problematic because the BebopClient is not cloneable at the moment
+        Box::new(self.clone())
     }
 }

--- a/src/evm/protocol/rfq/protocols/bebop.rs
+++ b/src/evm/protocol/rfq/protocols/bebop.rs
@@ -2,8 +2,7 @@ use async_trait::async_trait;
 
 use crate::{
     evm::protocol::rfq::{
-        client::RFQClientSource, errors::RFQError, indicative_price::IndicativePrice,
-        state::BindingQuote,
+        client::RFQClient, errors::RFQError, price_estimator::PriceEstimator, state::SignedQuote,
     },
     models::{GetAmountOutParams, Token},
     protocol::models::GetAmountOutResult,
@@ -18,7 +17,7 @@ pub struct BebopIndicativePrice {
 }
 
 #[async_trait]
-impl IndicativePrice for BebopIndicativePrice {
+impl PriceEstimator for BebopIndicativePrice {
     fn base_token(&self) -> &Token {
         &self.base_token
     }
@@ -36,7 +35,7 @@ impl IndicativePrice for BebopIndicativePrice {
         todo!()
     }
 
-    fn clone_box(&self) -> Box<dyn IndicativePrice> {
+    fn clone_box(&self) -> Box<dyn PriceEstimator> {
         Box::new(self.clone())
     }
 }
@@ -53,8 +52,8 @@ impl BebopClient {
 }
 
 #[async_trait]
-impl RFQClientSource for BebopClient {
-    async fn next_price_update(&mut self) -> Result<Vec<Box<dyn IndicativePrice>>, RFQError> {
+impl RFQClient for BebopClient {
+    async fn next_price_update(&mut self) -> Result<Vec<Box<dyn PriceEstimator>>, RFQError> {
         // get price data from Bebop
         todo!()
     }
@@ -62,12 +61,18 @@ impl RFQClientSource for BebopClient {
     async fn request_binding_quote(
         &self,
         params: &GetAmountOutParams,
-    ) -> Result<BindingQuote, RFQError> {
+    ) -> Result<SignedQuote, RFQError> {
         // get binding quote from Bebop
+        // we need to set gasless=false
+        // TODO: how are we going to handle approvals? https://docs.bebop.xyz/bebop/bebop-api-pmm-rfq/rfq-api-endpoints/trade/manage-approvals
+        // example request:
+        // curl -X 'GET' \
+        // 'https://api.bebop.xyz/pmm/ethereum/v3/quote?sell_tokens=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2&buy_tokens=0xdAC17F958D2ee523a2206206994597C13D831ec7&sell_amounts=1000000000000000&taker_address=0xabA2fC41e2dB95E77C6799D0F580034395FF2B9E&approval_type=Standard&skip_validation=true&skip_taker_checks=true&gasless=true&expiry_type=standard&fee=0&is_ui=false&gasless=false&origin_address=0x5206213Da4F6FE0E71d61cA00bB100dB2d6fe441' \
+        // -H 'accept: application/json'
         todo!()
     }
 
-    fn clone_box(&self) -> Box<dyn RFQClientSource> {
+    fn clone_box(&self) -> Box<dyn RFQClient> {
         Box::new(self.clone())
     }
 }

--- a/src/evm/protocol/rfq/protocols/bebop.rs
+++ b/src/evm/protocol/rfq/protocols/bebop.rs
@@ -1,0 +1,80 @@
+use async_trait::async_trait;
+
+use crate::{
+    evm::protocol::rfq::{
+        client::{IndicativePriceSource, RFQClientSource, WebSocketPriceStream},
+        indicative_price::IndicativePrice,
+        state::BindingQuote,
+    },
+    models::{GetAmountOutParams, Token},
+    protocol::{errors::SimulationError, models::GetAmountOutResult},
+};
+
+#[derive(Clone, Debug)]
+pub struct BebopIndicativePrice {
+    pub base_token: Token,
+    pub quote_token: Token,
+    pub bids: Vec<(f64, f64)>,
+    pub asks: Vec<(f64, f64)>,
+}
+
+#[async_trait]
+impl IndicativePrice for BebopIndicativePrice {
+    fn base_token(&self) -> &Token {
+        &self.base_token
+    }
+
+    fn quote_token(&self) -> &Token {
+        &self.quote_token
+    }
+
+    fn get_amount_out(
+        &self,
+        params: GetAmountOutParams,
+    ) -> Result<GetAmountOutResult, SimulationError> {
+        // use bids and asks to calculate the amount out
+        todo!()
+    }
+
+    fn clone_box(&self) -> Box<dyn IndicativePrice> {
+        Box::new(self.clone())
+    }
+}
+
+pub struct BebopClient {
+    // Fields for HTTP client, API keys, etc.
+    price_source: WebSocketPriceStream<BebopIndicativePrice>,
+}
+
+impl BebopClient {
+    pub fn new(price_source: WebSocketPriceStream<BebopIndicativePrice>) -> Self {
+        // TODO: figure out how to make a stream from the websocket
+        // let price_source = WebSocketPriceStream::new("wss://api.bebop.com/v1/price");
+        Self { price_source }
+    }
+}
+
+#[async_trait]
+impl RFQClientSource for BebopClient {
+    async fn next_price_update(
+        &mut self,
+    ) -> Result<Vec<Box<dyn IndicativePrice>>, SimulationError> {
+        self.price_source
+            .next_price_update()
+            .await
+    }
+
+    async fn request_binding_quote(
+        &self,
+        params: &GetAmountOutParams,
+    ) -> Result<BindingQuote, SimulationError> {
+        // gte binding quote from Bebop
+        todo!()
+    }
+
+    fn clone_box(&self) -> Box<dyn RFQClientSource> {
+        todo!()
+        //Box::new(self.clone())
+        // this is problematic because the BebopClient is not cloneable at the moment
+    }
+}

--- a/src/evm/protocol/rfq/protocols/bebop.rs
+++ b/src/evm/protocol/rfq/protocols/bebop.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-pub struct BebopIndicativePrice {
+pub struct BebopPriceEstimator {
     pub maker: String,
     pub base_token: String,
     pub quote_token: String,
@@ -18,7 +18,7 @@ pub struct BebopIndicativePrice {
 }
 
 #[async_trait]
-impl PriceEstimator for BebopIndicativePrice {
+impl PriceEstimator for BebopPriceEstimator {
     fn id(&self) -> String {
         format!("bebop-{}-{} {}", self.maker, self.base_token, self.quote_token)
     }

--- a/src/evm/protocol/rfq/protocols/bebop.rs
+++ b/src/evm/protocol/rfq/protocols/bebop.rs
@@ -74,6 +74,13 @@ impl RFQClient for BebopClient {
         // 'https://api.bebop.xyz/pmm/ethereum/v3/quote?sell_tokens=0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2&buy_tokens=0xdAC17F958D2ee523a2206206994597C13D831ec7&sell_amounts=1000000000000000&taker_address=0xabA2fC41e2dB95E77C6799D0F580034395FF2B9E&approval_type=Standard&skip_validation=true&skip_taker_checks=true&gasless=true&expiry_type=standard&fee=0&is_ui=false&gasless=false&origin_address=0x5206213Da4F6FE0E71d61cA00bB100dB2d6fe441' \
         // -H 'accept: application/json'
         todo!()
+        // in quote_attributes we need to save the whole tx and the toSign parameters
+        // then in encoding we will match the sender and receiver to the taker_address and
+        // maker_address.
+        // in execution we will need to check if the amountIn is the same as the quoted amount:
+        //   - if it's less, we need to do a partial fill https://docs.bebop.xyz/bebop/bebop-api-pmm-rfq/rfq-api-endpoints/trade/self-execute-order#partial-fills
+        //   - if it's more, we can only do the quoted amount and the rest will not be used (it will
+        //     either stay in the router or in the user or in the previous pool?)
     }
 
     fn clone_box(&self) -> Box<dyn RFQClient> {

--- a/src/evm/protocol/rfq/protocols/bebop.rs
+++ b/src/evm/protocol/rfq/protocols/bebop.rs
@@ -4,25 +4,25 @@ use crate::{
     evm::protocol::rfq::{
         client::RFQClient, errors::RFQError, price_estimator::PriceEstimator, state::SignedQuote,
     },
-    models::{GetAmountOutParams, Token},
+    models::GetAmountOutParams,
     protocol::models::GetAmountOutResult,
 };
 
 #[derive(Clone, Debug)]
 pub struct BebopIndicativePrice {
-    pub base_token: Token,
-    pub quote_token: Token,
+    pub base_token: String,
+    pub quote_token: String,
     pub bids: Vec<(f64, f64)>,
     pub asks: Vec<(f64, f64)>,
 }
 
 #[async_trait]
 impl PriceEstimator for BebopIndicativePrice {
-    fn base_token(&self) -> &Token {
+    fn base_token(&self) -> &String {
         &self.base_token
     }
 
-    fn quote_token(&self) -> &Token {
+    fn quote_token(&self) -> &String {
         &self.quote_token
     }
 

--- a/src/evm/protocol/rfq/protocols/bebop.rs
+++ b/src/evm/protocol/rfq/protocols/bebop.rs
@@ -2,10 +2,11 @@ use async_trait::async_trait;
 
 use crate::{
     evm::protocol::rfq::{
-        client::RFQClientSource, indicative_price::IndicativePrice, state::BindingQuote,
+        client::RFQClientSource, errors::RFQError, indicative_price::IndicativePrice,
+        state::BindingQuote,
     },
     models::{GetAmountOutParams, Token},
-    protocol::{errors::SimulationError, models::GetAmountOutResult},
+    protocol::models::GetAmountOutResult,
 };
 
 #[derive(Clone, Debug)]
@@ -26,10 +27,7 @@ impl IndicativePrice for BebopIndicativePrice {
         &self.quote_token
     }
 
-    fn get_amount_out(
-        &self,
-        params: GetAmountOutParams,
-    ) -> Result<GetAmountOutResult, SimulationError> {
+    fn get_amount_out(&self, params: GetAmountOutParams) -> Result<GetAmountOutResult, RFQError> {
         // use bids and asks to calculate the amount out
         todo!()
     }
@@ -56,9 +54,7 @@ impl BebopClient {
 
 #[async_trait]
 impl RFQClientSource for BebopClient {
-    async fn next_price_update(
-        &mut self,
-    ) -> Result<Vec<Box<dyn IndicativePrice>>, SimulationError> {
+    async fn next_price_update(&mut self) -> Result<Vec<Box<dyn IndicativePrice>>, RFQError> {
         // get price data from Bebop
         todo!()
     }
@@ -66,7 +62,7 @@ impl RFQClientSource for BebopClient {
     async fn request_binding_quote(
         &self,
         params: &GetAmountOutParams,
-    ) -> Result<BindingQuote, SimulationError> {
+    ) -> Result<BindingQuote, RFQError> {
         // get binding quote from Bebop
         todo!()
     }

--- a/src/evm/protocol/rfq/protocols/mod.rs
+++ b/src/evm/protocol/rfq/protocols/mod.rs
@@ -1,0 +1,1 @@
+mod bebop;

--- a/src/evm/protocol/rfq/state.rs
+++ b/src/evm/protocol/rfq/state.rs
@@ -1,0 +1,138 @@
+use std::{
+    any::Any,
+    collections::HashMap,
+    fmt::{Debug, Formatter},
+};
+
+use alloy_primitives::Address;
+use num_bigint::BigUint;
+use tycho_common::{dto::ProtocolStateDelta, Bytes};
+
+use crate::{
+    evm::protocol::rfq::{client::RFQClientSource, indicative_price::IndicativePrice},
+    models::{Balances, GetAmountOutParams, Token},
+    protocol::{
+        errors::{SimulationError, TransitionError},
+        models::GetAmountOutResult,
+        state::ProtocolSim,
+    },
+};
+
+pub struct RFQState {
+    pub base_token: Token,
+    pub quote_token: Token,
+    pub price_data: Box<dyn IndicativePrice>,
+    pub quote_provider: Box<dyn RFQClientSource>, // needed to get binding quote
+}
+
+impl RFQState {
+    pub fn new(
+        base_token: Token,
+        quote_token: Token,
+        price_data: Box<dyn IndicativePrice>,
+        quote_provider: Box<dyn RFQClientSource>,
+    ) -> Self {
+        RFQState { base_token, quote_token, price_data, quote_provider }
+    }
+}
+
+impl Debug for RFQState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        todo!()
+    }
+}
+
+impl ProtocolSim for RFQState {
+    fn get_amount_out(
+        &self,
+        amount_in: BigUint,
+        token_in: &Token,
+        token_out: &Token,
+    ) -> Result<GetAmountOutResult, SimulationError> {
+        self.price_data
+            .get_amount_out(GetAmountOutParams {
+                amount_in,
+                token_in: token_in.clone(),
+                token_out: token_out.clone(),
+            })
+    }
+
+    fn fee(&self) -> f64 {
+        todo!()
+    }
+
+    fn spot_price(&self, base: &Token, quote: &Token) -> Result<f64, SimulationError> {
+        todo!()
+    }
+
+    fn get_limits(
+        &self,
+        sell_token: Address,
+        buy_token: Address,
+    ) -> Result<(BigUint, BigUint), SimulationError> {
+        todo!()
+    }
+
+    fn delta_transition(
+        &mut self,
+        delta: ProtocolStateDelta,
+        tokens: &HashMap<Bytes, Token>,
+        balances: &Balances,
+    ) -> Result<(), TransitionError<String>> {
+        todo!()
+    }
+
+    fn clone_box(&self) -> Box<dyn ProtocolSim> {
+        todo!()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        todo!()
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        todo!()
+    }
+
+    fn eq(&self, other: &dyn ProtocolSim) -> bool {
+        todo!()
+    }
+}
+
+pub struct BindingQuote {
+    pub price: f64,
+    pub base_amount: f64,
+    pub quote_amount: f64,
+    pub signature: String,
+}
+
+// I don't like this name
+pub trait IndicativelyPriced: ProtocolSim {
+    fn is_indicatively_priced() -> bool {
+        false
+    }
+
+    async fn request_binding_quote(
+        &self,
+        params: GetAmountOutParams,
+    ) -> Result<BindingQuote, SimulationError> {
+        Err(SimulationError::NotImplemented)
+    }
+}
+
+impl IndicativelyPriced for RFQState {
+    fn is_indicatively_priced() -> bool {
+        true
+    }
+
+    async fn request_binding_quote(
+        &self,
+        params: GetAmountOutParams,
+    ) -> Result<BindingQuote, SimulationError> {
+        let binding_quote = self
+            .quote_provider
+            .request_binding_quote(&params)
+            .await?;
+        Ok(binding_quote)
+    }
+}

--- a/src/evm/protocol/rfq/state.rs
+++ b/src/evm/protocol/rfq/state.rs
@@ -19,20 +19,13 @@ use crate::{
 };
 
 pub struct RFQState {
-    pub base_token: Token,
-    pub quote_token: Token,
     pub price_data: Box<dyn PriceEstimator>,
     pub quote_provider: Box<dyn RFQClient>, // needed to get binding quote
 }
 
 impl RFQState {
-    pub fn new(
-        base_token: Token,
-        quote_token: Token,
-        price_data: Box<dyn PriceEstimator>,
-        quote_provider: Box<dyn RFQClient>,
-    ) -> Self {
-        RFQState { base_token, quote_token, price_data, quote_provider }
+    pub fn new(price_data: Box<dyn PriceEstimator>, quote_provider: Box<dyn RFQClient>) -> Self {
+        RFQState { price_data, quote_provider }
     }
 }
 

--- a/src/evm/protocol/rfq/state.rs
+++ b/src/evm/protocol/rfq/state.rs
@@ -48,6 +48,8 @@ impl ProtocolSim for RFQState {
                 amount_in,
                 token_in: token_in.clone(),
                 token_out: token_out.clone(),
+                sender: Bytes::new(),
+                receiver: Bytes::new(),
             })?)
     }
 

--- a/src/evm/protocol/rfq/state.rs
+++ b/src/evm/protocol/rfq/state.rs
@@ -49,12 +49,13 @@ impl ProtocolSim for RFQState {
         token_in: &Token,
         token_out: &Token,
     ) -> Result<GetAmountOutResult, SimulationError> {
-        self.price_data
+        Ok(self
+            .price_data
             .get_amount_out(GetAmountOutParams {
                 amount_in,
                 token_in: token_in.clone(),
                 token_out: token_out.clone(),
-            })
+            })?)
     }
 
     fn fee(&self) -> f64 {

--- a/src/evm/protocol/rfq/stream.rs
+++ b/src/evm/protocol/rfq/stream.rs
@@ -1,0 +1,56 @@
+use std::sync::Mutex;
+
+use crate::evm::protocol::rfq::{client::RFQClientSource, state::RFQState};
+
+pub struct RFQStreamBuilder {
+    // example: ("bebop", BebopClient)
+    providers: Vec<(String, Mutex<Box<dyn RFQClientSource>>)>,
+}
+
+impl RFQStreamBuilder {
+    pub fn new() -> Self {
+        Self { providers: Vec::new() }
+    }
+
+    pub fn add_provider(&mut self, provider: String, source: Mutex<Box<dyn RFQClientSource>>) {
+        self.providers.push((provider, source));
+    }
+
+    pub async fn build(self, tx: tokio::sync::mpsc::Sender<Vec<RFQState>>) {
+        let sources: Vec<Mutex<Box<dyn RFQClientSource>>> = self
+            .providers
+            .into_iter()
+            .map(|(_, source)| source)
+            .collect();
+        stream_rfq_states(sources, tx).await;
+    }
+}
+
+pub async fn stream_rfq_states(
+    sources: Vec<Mutex<Box<dyn RFQClientSource>>>,
+    tx: tokio::sync::mpsc::Sender<Vec<RFQState>>,
+) {
+    loop {
+        let mut states = Vec::new();
+
+        for source in &sources {
+            let mut locked_source = source.lock().unwrap();
+            match locked_source.next_price_update().await {
+                Ok(prices_data) => {
+                    for data in prices_data.iter() {
+                        let state = RFQState::new(
+                            data.base_token().clone(),
+                            data.quote_token().clone(),
+                            data.clone_box(),
+                            locked_source.clone_box(),
+                        );
+                        states.push(state);
+                    }
+                }
+                Err(err) => {
+                    eprintln!("Error updating price: {:?}", err);
+                }
+            }
+        }
+    }
+}

--- a/src/evm/protocol/rfq/stream.rs
+++ b/src/evm/protocol/rfq/stream.rs
@@ -1,10 +1,10 @@
 use std::sync::Mutex;
 
-use crate::evm::protocol::rfq::{client::RFQClientSource, state::RFQState};
+use crate::evm::protocol::rfq::{client::RFQClient, state::RFQState};
 
 pub struct RFQStreamBuilder {
     // example: ("bebop", BebopClient)
-    providers: Vec<(String, Mutex<Box<dyn RFQClientSource>>)>,
+    providers: Vec<(String, Mutex<Box<dyn RFQClient>>)>,
 }
 
 impl RFQStreamBuilder {
@@ -12,12 +12,12 @@ impl RFQStreamBuilder {
         Self { providers: Vec::new() }
     }
 
-    pub fn add_provider(&mut self, provider: String, source: Mutex<Box<dyn RFQClientSource>>) {
+    pub fn add_provider(&mut self, provider: String, source: Mutex<Box<dyn RFQClient>>) {
         self.providers.push((provider, source));
     }
 
     pub async fn build(self, tx: tokio::sync::mpsc::Sender<Vec<RFQState>>) {
-        let sources: Vec<Mutex<Box<dyn RFQClientSource>>> = self
+        let sources: Vec<Mutex<Box<dyn RFQClient>>> = self
             .providers
             .into_iter()
             .map(|(_, source)| source)
@@ -27,7 +27,7 @@ impl RFQStreamBuilder {
 }
 
 pub async fn stream_rfq_states(
-    sources: Vec<Mutex<Box<dyn RFQClientSource>>>,
+    sources: Vec<Mutex<Box<dyn RFQClient>>>,
     tx: tokio::sync::mpsc::Sender<Vec<RFQState>>,
 ) {
     loop {

--- a/src/evm/stream.rs
+++ b/src/evm/stream.rs
@@ -14,7 +14,7 @@ use crate::{
     models::Token,
     protocol::{
         errors::InvalidSnapshotError,
-        models::{BlockUpdate, TryFromWithBlock},
+        models::{TryFromWithBlock, Update},
         state::ProtocolSim,
     },
 };
@@ -143,7 +143,7 @@ impl ProtocolStreamBuilder {
 
     pub async fn build(
         self,
-    ) -> Result<impl Stream<Item = Result<BlockUpdate, StreamDecodeError>>, StreamError> {
+    ) -> Result<impl Stream<Item = Result<Update, StreamDecodeError>>, StreamError> {
         let (_, rx) = self.stream_builder.build().await?;
         let decoder = Arc::new(self.decoder);
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -117,6 +117,12 @@ impl TryFrom<ResponseToken> for Token {
     }
 }
 
+pub struct GetAmountOutParams {
+    pub amount_in: BigUint,
+    pub token_in: Token,
+    pub token_out: Token,
+}
+
 #[derive(Default)]
 pub struct Balances {
     pub component_balances: HashMap<String, HashMap<Bytes, Bytes>>,

--- a/src/models.rs
+++ b/src/models.rs
@@ -121,6 +121,8 @@ pub struct GetAmountOutParams {
     pub amount_in: BigUint,
     pub token_in: Token,
     pub token_out: Token,
+    pub sender: Bytes,
+    pub receiver: Bytes,
 }
 
 #[derive(Default)]

--- a/src/protocol/errors.rs
+++ b/src/protocol/errors.rs
@@ -55,6 +55,8 @@ pub enum SimulationError {
     InvalidInput(String, Option<GetAmountOutResult>),
     #[error("Recoverable error: {0}")]
     RecoverableError(String),
+    #[error("Not implemented error")]
+    NotImplemented,
 }
 
 impl<T> From<SimulationError> for TransitionError<T> {
@@ -95,5 +97,11 @@ impl From<io::Error> for FileError {
 impl From<SerdeError> for FileError {
     fn from(err: SerdeError) -> Self {
         FileError::Parse(err)
+    }
+}
+
+impl From<reqwest::Error> for SimulationError {
+    fn from(err: reqwest::Error) -> Self {
+        SimulationError::FatalError(err.to_string())
     }
 }

--- a/src/protocol/errors.rs
+++ b/src/protocol/errors.rs
@@ -99,9 +99,3 @@ impl From<SerdeError> for FileError {
         FileError::Parse(err)
     }
 }
-
-impl From<reqwest::Error> for SimulationError {
-    fn from(err: reqwest::Error) -> Self {
-        SimulationError::FatalError(err.to_string())
-    }
-}

--- a/src/protocol/models.rs
+++ b/src/protocol/models.rs
@@ -53,6 +53,7 @@ pub struct ProtocolComponent {
     pub static_attributes: HashMap<String, Bytes>,
     pub creation_tx: Bytes,
     pub created_at: NaiveDateTime,
+    pub additional_execution_data: Option<HashMap<String, Bytes>>,
 }
 
 impl ProtocolComponent {
@@ -80,6 +81,7 @@ impl ProtocolComponent {
             static_attributes,
             creation_tx,
             created_at,
+            additional_execution_data: None,
         }
     }
 
@@ -100,6 +102,14 @@ impl ProtocolComponent {
             core_model.creation_tx,
             core_model.created_at,
         )
+    }
+
+    pub fn additional_execution_data(
+        mut self,
+        additional_execution_data: HashMap<String, Bytes>,
+    ) -> Self {
+        self.additional_execution_data = Some(additional_execution_data);
+        self
     }
 }
 

--- a/src/protocol/models.rs
+++ b/src/protocol/models.rs
@@ -176,7 +176,8 @@ impl GetAmountOutResult {
 }
 
 #[derive(Debug)]
-pub struct BlockUpdate {
+pub struct Update {
+    pub marker: u64,
     pub block_number: u64,
     /// The new and updated states of this block
     pub states: HashMap<String, Box<dyn ProtocolSim>>,
@@ -186,13 +187,19 @@ pub struct BlockUpdate {
     pub removed_pairs: HashMap<String, ProtocolComponent>,
 }
 
-impl BlockUpdate {
+impl Update {
     pub fn new(
-        block_number: u64,
+        marker: u64,
         states: HashMap<String, Box<dyn ProtocolSim>>,
         new_pairs: HashMap<String, ProtocolComponent>,
     ) -> Self {
-        BlockUpdate { block_number, states, new_pairs, removed_pairs: HashMap::new() }
+        Update {
+            marker: marker.clone(),
+            block_number: marker,
+            states,
+            new_pairs,
+            removed_pairs: HashMap::new(),
+        }
     }
 
     pub fn set_removed_pairs(mut self, pairs: HashMap<String, ProtocolComponent>) -> Self {


### PR DESCRIPTION
This is a rough draft and I'm not 100% convinced yet. I'm open to opinions and changes 🙏🏼 
On the bright side, this builds without errors (only warnings). I left some comments in problematic places (like cloning and etc..).

Splitting the plan into two parts:
1. Fetching price levels/formulas/wtv from the RFQ API, creating the pool states and calculating indicative prices (in `get_amount_out` and `spot_prices`
2. Requesting a binding quote.

### 1. 
**`PriceEstimator` trait** this is to define how the amount out gets calculated (spot prices should be here too). It will be different per RFQ.
**`RFQClient`** trait is to define the connections to the RFQ API. It has two methods: `next_price_update` and `request_binding_quote`.
**`RFQState` struct** is our normal Pool State (it implements `ProtocolSim` as well). It holds the `PriceEstimator` implementations and also the `RFQClient` so that it can request the binding quote at 2.

### 2.
**`IndicativelyPriced`** trait marks protocols that support indicative pricing and optionally binding quotes. This way the user can call `request_binding_quote` at any time after it gets the `RFQState`s
Added an `additional_execution_data` attribute to `ProtocolComponent`. The binding quote needs to be passed here and the user is responsible for doing it.

### Execution
Most RFQs allow to set the sender and receiver to whatever we want (this must be done when requesting the signed quote). We only know the sender and the receiver at encoding time, so ideally the request for quote needs to be done inside encoding. This means mega refactor. Encoding needs to be able to access the `ProtocolSim` implementations. We can do that by moving some structs and traits from tycho-simulation to tycho-common.

### TODOs
- This plan is only for RFQs like Bebop, Hashflow, Native and Swaap. Clipper and Valantis do not currently fit into this design 😕 


