### PR TITLE
fix: update tycho-client to version 0.70.5

### DIFF
--- a/.github/workflows/tests-and-lints-template.yaml
+++ b/.github/workflows/tests-and-lints-template.yaml
@@ -122,6 +122,7 @@ jobs:
       - name: Setup rustfmt toolchain - nightly
         uses: dtolnay/rust-toolchain@a02741459ec5e501b9843ed30b535ca0a0376ae4
         with:
+          toolchain: nightly
           components: rustfmt
 
       - run: cargo +nightly fmt --all --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8093,9 +8093,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.70.3"
+version = "0.70.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11afbfa0c211b1d65b7b6fe7992bb634e91ddee264e4bf8038104fa1a2d03f6f"
+checksum = "407cc27e284d27e8826df2bf1a0f67397a1c0c5efe218fd777d882cf6bdb631c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8120,9 +8120,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-common"
-version = "0.70.3"
+version = "0.70.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68cff315416f335afcd7619ff49aa7c85ec84d26d4c8187c548588fce228926"
+checksum = "22afc488ba537fb646c697fbe93e0abcccb2c34c9bcb0ef5064363f5b1444d5d"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,8 @@ mini-moka = "0.10"
 lazy_static = "1.4.0"
 
 # Tycho dependencies
-tycho-common = "0.70.3"
-tycho-client = "0.70.3"
+tycho-common = "0.70.5"
+tycho-client = "0.70.5"
 
 # EVM dependencies
 foundry-config = { git = "https://github.com/foundry-rs/foundry", rev = "57bb12e", optional = true }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
-components = ["rustfmt"]
+channel = "stable"
+components = ["clippy"]


### PR DESCRIPTION
This client version contains fixes for the smooth handling of delayed extractors.