### PR TITLE
feat: Add component TVL tracking and update BlockUpdate

### DIFF
--- a/src/evm/stream.rs
+++ b/src/evm/stream.rs
@@ -124,6 +124,13 @@ impl ProtocolStreamBuilder {
         self
     }
 
+    pub fn include_tvl(mut self, include_tvl: bool) -> Self {
+        self.stream_builder = self
+            .stream_builder
+            .include_tvl(include_tvl);
+        self
+    }
+
     /// Sets the currently known tokens which to be considered during decoding.
     ///
     /// Protocol components containing tokens which are not included in this initial list, or

--- a/src/protocol/models.rs
+++ b/src/protocol/models.rs
@@ -175,6 +175,8 @@ pub struct BlockUpdate {
     pub new_pairs: HashMap<String, ProtocolComponent>,
     /// The pairs that were removed in this block
     pub removed_pairs: HashMap<String, ProtocolComponent>,
+    /// The total value locked (TVL) of each component in this block
+    pub component_tvl: HashMap<String, f64>,
 }
 
 impl BlockUpdate {
@@ -183,11 +185,22 @@ impl BlockUpdate {
         states: HashMap<String, Box<dyn ProtocolSim>>,
         new_pairs: HashMap<String, ProtocolComponent>,
     ) -> Self {
-        BlockUpdate { block_number, states, new_pairs, removed_pairs: HashMap::new() }
+        BlockUpdate {
+            block_number,
+            states,
+            new_pairs,
+            removed_pairs: HashMap::new(),
+            component_tvl: HashMap::new(),
+        }
     }
 
     pub fn set_removed_pairs(mut self, pairs: HashMap<String, ProtocolComponent>) -> Self {
         self.removed_pairs = pairs;
+        self
+    }
+
+    pub fn set_component_tvl(mut self, component_tvl: HashMap<String, f64>) -> Self {
+        self.component_tvl = component_tvl;
         self
     }
 }

--- a/tests/assets/decoder/uniswap_v2_with_tvl_delta.json
+++ b/tests/assets/decoder/uniswap_v2_with_tvl_delta.json
@@ -1,0 +1,75 @@
+{
+  "state_msgs": {
+    "uniswap_v2": {
+      "header": {
+        "hash": "0xf4e2dbcd5b099aa46f8cff87291f71fb0aa298b5a8cdaba567bb2950b9a15d36",
+        "number": 22641717,
+        "parent_hash": "0x970e70875fbf0a22792acca3a98ffe325b74ee27a367a0a4bcadcf5287549e15",
+        "revert": false
+      },
+      "snapshots": {
+        "states": {},
+        "vm_storage": {}
+      },
+      "deltas": {
+        "extractor": "uniswap_v2",
+        "chain": "ethereum",
+        "block": {
+          "number": 22641717,
+          "hash": "0xf4e2dbcd5b099aa46f8cff87291f71fb0aa298b5a8cdaba567bb2950b9a15d36",
+          "parent_hash": "0x970e70875fbf0a22792acca3a98ffe325b74ee27a367a0a4bcadcf5287549e15",
+          "chain": "ethereum",
+          "ts": "2025-06-05T23:34:35"
+        },
+        "finalized_block_height": 22641638,
+        "revert": false,
+        "new_tokens": {},
+        "account_updates": {},
+        "state_updates": {
+          "0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852": {
+            "component_id": "0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852",
+            "updated_attributes": {
+              "reserve0": "0x01bafbe6925e17a5874f",
+              "reserve1": "0x120a8a1b2da6"
+            },
+            "deleted_attributes": []
+          }
+        },
+        "new_protocol_components": {},
+        "deleted_protocol_components": {},
+        "component_balances": {
+          "0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852": {
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": {
+              "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+              "balance": "0x01bafbe6925e17a5874f",
+              "balance_float": 8.171612236860606e21,
+              "modify_tx": "0x48197e792039221661cd8313297b2da9f59c38de8225f253d911de727eab96ab",
+              "component_id": "0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852"
+            },
+            "0xdac17f958d2ee523a2206206994597c13d831ec7": {
+              "token": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+              "balance": "0x120a8a1b2da6",
+              "balance_float": 19836476009894.0,
+              "modify_tx": "0x48197e792039221661cd8313297b2da9f59c38de8225f253d911de727eab96ab",
+              "component_id": "0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852"
+            }
+          }
+        },
+        "account_balances": {},
+        "component_tvl": {
+          "0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852": 16331.518308333754
+        }
+      },
+      "removed_components": {}
+    }
+  },
+  "sync_states": {
+    "uniswap_v2": {
+      "status": "ready",
+      "hash": "0xf4e2dbcd5b099aa46f8cff87291f71fb0aa298b5a8cdaba567bb2950b9a15d36",
+      "number": 22641717,
+      "parent_hash": "0x970e70875fbf0a22792acca3a98ffe325b74ee27a367a0a4bcadcf5287549e15",
+      "revert": false
+    }
+  }
+}

--- a/tests/assets/decoder/uniswap_v2_with_tvl_snapshot.json
+++ b/tests/assets/decoder/uniswap_v2_with_tvl_snapshot.json
@@ -1,0 +1,155 @@
+{
+  "state_msgs": {
+    "uniswap_v2": {
+      "header": {
+        "hash": "0x970e70875fbf0a22792acca3a98ffe325b74ee27a367a0a4bcadcf5287549e15",
+        "number": 22641716,
+        "parent_hash": "0xada2a59c39ae93e755a71e9479297bb1fd0bfbb63515b071d9faf454409860a9",
+        "revert": false
+      },
+      "snapshots": {
+        "states": {
+          "0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852": {
+            "state": {
+              "component_id": "0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852",
+              "attributes": {
+                "reserve1": "0x120b4a9d8626",
+                "reserve0": "0x01bae9623da649d60c8c"
+              },
+              "balances": {
+                "0xdac17f958d2ee523a2206206994597c13d831ec7": "0x120b4a9d8626",
+                "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": "0x01bae9623da649d60c8c"
+              }
+            },
+            "component": {
+              "id": "0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852",
+              "protocol_system": "uniswap_v2",
+              "protocol_type_name": "uniswap_v2_pool",
+              "chain": "ethereum",
+              "tokens": ["0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", "0xdac17f958d2ee523a2206206994597c13d831ec7"],
+              "contract_ids": [],
+              "static_attributes": {
+                "pool_address": "0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852",
+                "fee": "0x1e"
+              },
+              "change": "Creation",
+              "creation_tx": "0xe64069acd123ec94b8a3316378183ba8bf42b40979df3b0bb57b0e7b9e47ef38",
+              "created_at": "2020-05-19T01:07:09"
+            },
+            "component_tvl": 16331.458456164766
+          }
+        },
+        "vm_storage": {}
+      },
+      "deltas": {
+        "extractor": "uniswap_v2",
+        "chain": "ethereum",
+        "block": {
+          "number": 22641716,
+          "hash": "0x970e70875fbf0a22792acca3a98ffe325b74ee27a367a0a4bcadcf5287549e15",
+          "parent_hash": "0xada2a59c39ae93e755a71e9479297bb1fd0bfbb63515b071d9faf454409860a9",
+          "chain": "ethereum",
+          "ts": "2025-06-05T23:34:23"
+        },
+        "finalized_block_height": 22641638,
+        "revert": false,
+        "new_tokens": {},
+        "account_updates": {},
+        "state_updates": {
+          "0x2621cc0b3f3c079c1db0e80794aa24976f0b9e3c": {
+            "component_id": "0x2621cc0b3f3c079c1db0e80794aa24976f0b9e3c",
+            "updated_attributes": {
+              "reserve0": "0x5efa7222be1eb032f16d0f",
+              "reserve1": "0x06dece7e444ccc44dac039"
+            },
+            "deleted_attributes": []
+          },
+          "0x5ced44f03ff443bbe14d8ea23bc24425fb89e3ed": {
+            "component_id": "0x5ced44f03ff443bbe14d8ea23bc24425fb89e3ed",
+            "updated_attributes": {
+              "reserve0": "0x16ac1021ab8d3a4c3ac044ba",
+              "reserve1": "0x1c1f7438049a0bb7e4"
+            },
+            "deleted_attributes": []
+          },
+          "0xcaa004418eb42cdf00cb057b7c9e28f0ffd840a5": {
+            "component_id": "0xcaa004418eb42cdf00cb057b7c9e28f0ffd840a5",
+            "updated_attributes": {
+              "reserve0": "0x090039bc8eedcb154c1ee7",
+              "reserve1": "0x2d16a7f174447c6c0e"
+            },
+            "deleted_attributes": []
+          }
+        },
+        "new_protocol_components": {},
+        "deleted_protocol_components": {},
+        "component_balances": {
+          "0xcaa004418eb42cdf00cb057b7c9e28f0ffd840a5": {
+            "0x2a3bff78b79a009976eea096a51a948a3dc00e34": {
+              "token": "0x2a3bff78b79a009976eea096a51a948a3dc00e34",
+              "balance": "0x090039bc8eedcb154c1ee7",
+              "balance_float": 1.0881397428002446e25,
+              "modify_tx": "0xb25e1f32f509ed0c752efd26176f97edc76394dd2f1ac6b91288b705fa7049a8",
+              "component_id": "0xcaa004418eb42cdf00cb057b7c9e28f0ffd840a5"
+            },
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": {
+              "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+              "balance": "0x2d16a7f174447c6c0e",
+              "balance_float": 8.317360221885424e20,
+              "modify_tx": "0xb25e1f32f509ed0c752efd26176f97edc76394dd2f1ac6b91288b705fa7049a8",
+              "component_id": "0xcaa004418eb42cdf00cb057b7c9e28f0ffd840a5"
+            }
+          },
+          "0x2621cc0b3f3c079c1db0e80794aa24976f0b9e3c": {
+            "0x56072c95faa701256059aa122697b133aded9279": {
+              "token": "0x56072c95faa701256059aa122697b133aded9279",
+              "balance": "0x5efa7222be1eb032f16d0f",
+              "balance_float": 1.1482172409678914e26,
+              "modify_tx": "0x4d07a037bcc4baea79bc7c1b96e56153048517f89f7acc84d49668b8d601cdc5",
+              "component_id": "0x2621cc0b3f3c079c1db0e80794aa24976f0b9e3c"
+            },
+            "0xdc035d45d973e3ec169d2276ddab16f1e407384f": {
+              "token": "0xdc035d45d973e3ec169d2276ddab16f1e407384f",
+              "balance": "0x06dece7e444ccc44dac039",
+              "balance_float": 8.305729404645608e24,
+              "modify_tx": "0x4d07a037bcc4baea79bc7c1b96e56153048517f89f7acc84d49668b8d601cdc5",
+              "component_id": "0x2621cc0b3f3c079c1db0e80794aa24976f0b9e3c"
+            }
+          },
+          "0x5ced44f03ff443bbe14d8ea23bc24425fb89e3ed": {
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2": {
+              "token": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+              "balance": "0x1c1f7438049a0bb7e4",
+              "balance_float": 5.1877533216875715e20,
+              "modify_tx": "0xd3d4cfc37ad0bbb1b19f2a9ab750871ca95518f0ede4a66bffc6aaa3a76bb28d",
+              "component_id": "0x5ced44f03ff443bbe14d8ea23bc24425fb89e3ed"
+            },
+            "0x594daad7d77592a2b97b725a7ad59d7e188b5bfa": {
+              "token": "0x594daad7d77592a2b97b725a7ad59d7e188b5bfa",
+              "balance": "0x16ac1021ab8d3a4c3ac044ba",
+              "balance_float": 7.016681636011188e27,
+              "modify_tx": "0xd3d4cfc37ad0bbb1b19f2a9ab750871ca95518f0ede4a66bffc6aaa3a76bb28d",
+              "component_id": "0x5ced44f03ff443bbe14d8ea23bc24425fb89e3ed"
+            }
+          }
+        },
+        "account_balances": {},
+        "component_tvl": {
+          "0x5ced44f03ff443bbe14d8ea23bc24425fb89e3ed": 1040.9151541920612,
+          "0xcaa004418eb42cdf00cb057b7c9e28f0ffd840a5": 1665.1578749759788,
+          "0x2621cc0b3f3c079c1db0e80794aa24976f0b9e3c": 6837.077225071193
+        }
+      },
+      "removed_components": {}
+    }
+  },
+  "sync_states": {
+    "uniswap_v2": {
+      "status": "ready",
+      "hash": "0x970e70875fbf0a22792acca3a98ffe325b74ee27a367a0a4bcadcf5287549e15",
+      "number": 22641716,
+      "parent_hash": "0xada2a59c39ae93e755a71e9479297bb1fd0bfbb63515b071d9faf454409860a9",
+      "revert": false
+    }
+  }
+}


### PR DESCRIPTION
Close #211 
- Add `include_tvl` flag to ProtocolStreamBuilder
- Extend BlockUpdate with `component_tvl: HashMap<String, f64>`
- Decode `component_tvl` from both snapshots and deltas in `TychoStreamDecoder`
- Add basic tests for TVL decoding