### PR TITLE
fix(python): Do not error on account balances for non-pool tokens

### DIFF
--- a/tycho_simulation_py/python/tycho_simulation_py/evm/decoders.py
+++ b/tycho_simulation_py/python/tycho_simulation_py/evm/decoders.py
@@ -279,10 +279,14 @@ class ThirdPartyPoolTychoDecoder(TychoDecoder):
         balances = {}
         for addr, balance in balances_msg.items():
             checksum_addr = to_checksum_address(addr)
-            token = next(t for t in tokens if t.address == checksum_addr)
-            balances[token.address] = token.from_onchain_amount(
-                int(balance)  # balances are big endian encoded
-            )
+            try:
+                token = next(t for t in tokens if t.address == checksum_addr)
+                balances[token.address] = token.from_onchain_amount(
+                    int(balance)  # balances are big endian encoded
+                )
+            except StopIteration:
+                # Skip this balance if no matching token is found
+                continue
         return balances
 
     def apply_deltas(


### PR DESCRIPTION
Account balances include balances for all tokens held by that account, regardless of if that token is associated with the current pool being decoded. Since the python decoder reports balances in off-chain amounts, it's important that we have the token object for all balances we're processing so that we can do this conversion. Therefore, to avoid issues we should only process account balances for tokens that belong to the pool being decoded.