### PR TITLE
feat: Upgrade tycho-execution to 0.102.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8244,9 +8244,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.97.0"
+version = "0.102.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822993a3677bf147ff75b3a66229b49bcc7af4c393f8818ebf86093a987c578b"
+checksum = "2b8d945afd402bc18b978d8abce58d9df4cb52746f2832a98f2f307b1bbde1b8"
 dependencies = [
  "alloy",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ unicode-width = "0.1.13"
 tracing-appender = "0.2.3"
 
 # tycho execution for quickstart
-tycho-execution = "0.97.0"
+tycho-execution = "0.102.0"
 
 [features]
 default = ["evm"]

--- a/examples/quickstart/main.rs
+++ b/examples/quickstart/main.rs
@@ -618,6 +618,7 @@ fn create_solution(
         // Split defines the fraction of the amount to be swapped. A value of 0 indicates 100% of
         // the amount or the total remaining balance.
         0f64,
+        None,
     );
 
     // Compute a minimum amount out


### PR DESCRIPTION
This supports the new Ekubo executor with MEV resist