### PR TITLE
fix: Add a merge method to Update

### DIFF
--- a/src/protocol/models.rs
+++ b/src/protocol/models.rs
@@ -166,4 +166,12 @@ impl Update {
         self.removed_pairs = pairs;
         self
     }
+
+    pub fn merge(mut self, other: Update) -> Self {
+        self.states.extend(other.states);
+        self.new_pairs.extend(other.new_pairs);
+        self.removed_pairs
+            .extend(other.removed_pairs);
+        self
+    }
 }


### PR DESCRIPTION
This is just a helper function for the user to use if they want to merge Updates for RFQs within the same time window