### PR TITLE
feat(Hashflow): Hashflow price levels API client

### DIFF
--- a/examples/price_printer/main.rs
+++ b/examples/price_printer/main.rs
@@ -32,7 +32,7 @@ use tycho_simulation::{
 #[derive(Parser)]
 struct Cli {
     /// The tvl threshold to filter the graph by
-    #[arg(short, long, default_value_t = 1000.0)]
+    #[arg(long, default_value_t = 1000.0)]
     tvl_threshold: f64,
     /// The target blockchain
     #[clap(long, default_value = "ethereum")]

--- a/examples/quickstart/main.rs
+++ b/examples/quickstart/main.rs
@@ -61,18 +61,18 @@ const FAKE_PK: &str = "0x123456789abcdef123456789abcdef123456789abcdef123456789a
 
 #[derive(Parser)]
 struct Cli {
-    #[arg(short, long)]
+    #[arg(long)]
     sell_token: Option<String>,
-    #[arg(short, long)]
+    #[arg(long)]
     buy_token: Option<String>,
-    #[arg(short, long, default_value_t = 10.0)]
+    #[arg(long, default_value_t = 10.0)]
     sell_amount: f64,
     /// The tvl threshold to filter the graph by
-    #[arg(short, long, default_value_t = 100.0)]
+    #[arg(long, default_value_t = 100.0)]
     tvl_threshold: f64,
-    #[arg(short, long, default_value = FAKE_PK)]
+    #[arg(long, default_value = FAKE_PK)]
     swapper_pk: String,
-    #[arg(short, long, default_value = "ethereum")]
+    #[arg(long, default_value = "ethereum")]
     chain: String,
 }
 

--- a/examples/rfq_quickstart/main.rs
+++ b/examples/rfq_quickstart/main.rs
@@ -18,16 +18,16 @@ use tycho_simulation::{
 
 #[derive(Parser)]
 struct Cli {
-    #[arg(short, long)]
+    #[arg(long)]
     sell_token: Option<String>,
-    #[arg(short, long)]
+    #[arg(long)]
     buy_token: Option<String>,
-    #[arg(short, long, default_value_t = 10.0)]
+    #[arg(long, default_value_t = 10.0)]
     sell_amount: f64,
     /// The minimum TVL threshold for RFQ quotes in USD
-    #[arg(short, long, default_value_t = 1.0)]
+    #[arg(long, default_value_t = 1.0)]
     tvl_threshold: f64,
-    #[arg(short, long, default_value = "ethereum")]
+    #[arg(long, default_value = "ethereum")]
     chain: Chain,
 }
 

--- a/src/rfq/protocols/hashflow/client.rs
+++ b/src/rfq/protocols/hashflow/client.rs
@@ -1,0 +1,535 @@
+#![allow(dead_code)] // TODO remove this
+use std::{
+    collections::{HashMap, HashSet},
+    time::SystemTime,
+};
+
+use alloy::primitives::utils::keccak256;
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use reqwest::Client;
+use tokio::time::{interval, Duration};
+use tracing::{error, info};
+use tycho_common::{
+    models::{protocol::GetAmountOutParams, Chain},
+    simulation::indicatively_priced::SignedQuote,
+    Bytes,
+};
+
+use crate::{
+    rfq::{
+        client::RFQClient,
+        errors::RFQError,
+        models::TimestampHeader,
+        protocols::hashflow::models::{
+            HashflowMarketMakerLevel, HashflowMarketMakersResponse, HashflowPriceLevelsResponse,
+        },
+    },
+    tycho_client::feed::synchronizer::{ComponentWithState, Snapshot, StateSyncMessage},
+    tycho_common::dto::{ProtocolComponent, ResponseProtocolState},
+};
+
+#[derive(Clone)]
+pub struct HashflowClient {
+    chain: Chain,
+    chain_id: u32,
+    price_levels_endpoint: String,
+    market_makers_endpoint: String,
+    quote_endpoint: String,
+    // Tokens that we want prices for
+    tokens: HashSet<Bytes>,
+    // Min tvl value in the quote token.
+    tvl: f64,
+    http_client: Client,
+    auth_key: String,
+    source: String,
+    // Quote tokens to normalize to for TVL purposes. Should have the same prices.
+    quote_tokens: HashSet<Bytes>,
+    market_makers: Vec<String>,
+}
+
+impl HashflowClient {
+    pub fn new(
+        chain: Chain,
+        tokens: HashSet<Bytes>,
+        tvl: f64,
+        quote_tokens: HashSet<Bytes>,
+        auth_key: String,
+    ) -> Result<Self, RFQError> {
+        let chain_id = chain.id() as u32;
+
+        Ok(Self {
+            chain,
+            chain_id,
+            price_levels_endpoint: "https://api.hashflow.com/taker/v3/price-levels".to_string(),
+            market_makers_endpoint: "https://api.hashflow.com/taker/v3/market-makers".to_string(),
+            quote_endpoint: "https://api.hashflow.com/taker/v3/rfq".to_string(),
+            tokens,
+            tvl,
+            http_client: Client::new(),
+            auth_key,
+            source: "propellerheads".to_string(),
+            quote_tokens,
+            market_makers: Vec::new(), // Will be populated during first fetch
+        })
+    }
+
+    /// Normalize TVL to a common quote token for comparison
+    /// Returns the normalized TVL value, or 0.0 if normalization fails due to no liquidity
+    fn normalize_tvl(
+        &self,
+        raw_tvl: f64,
+        quote_token: Bytes,
+        levels_by_mm: &HashMap<String, Vec<HashflowMarketMakerLevel>>,
+    ) -> Result<f64, RFQError> {
+        // If the quote token is already in our approved quote token set, no conversion needed
+        if self.quote_tokens.contains(&quote_token) {
+            return Ok(raw_tvl);
+        }
+
+        // Try to find the price of the quote token in one of the approved quote tokens
+        // for normalization.
+        for approved_quote_token in &self.quote_tokens {
+            for (_mm, mm_levels_inner) in levels_by_mm.iter() {
+                for quote_mm_level in mm_levels_inner {
+                    // Check for direct pair: quote_token/approved_quote_token
+                    if quote_mm_level.pair.base_token == quote_token &&
+                        quote_mm_level.pair.quote_token == *approved_quote_token
+                    {
+                        if let Some(price) = quote_mm_level.get_price(1.0) {
+                            return Ok(raw_tvl * price);
+                        }
+                    }
+                }
+            }
+        }
+
+        // If we can't normalize, return TVL 0 (pool will be filtered out)
+        Ok(0.0)
+    }
+
+    fn create_component_with_state(
+        &self,
+        component_id: String,
+        tokens: Vec<Bytes>,
+        mm_name: &str,
+        mm_level: &HashflowMarketMakerLevel,
+        tvl: f64,
+    ) -> ComponentWithState {
+        let protocol_component = ProtocolComponent {
+            id: component_id.clone(),
+            protocol_system: "rfq:hashflow".to_string(),
+            protocol_type_name: "hashflow_pool".to_string(),
+            chain: self.chain.into(),
+            tokens,
+            contract_ids: vec![], // empty for RFQ
+            static_attributes: Default::default(),
+            change: Default::default(),
+            creation_tx: Default::default(),
+            created_at: Default::default(),
+        };
+
+        let mut attributes = HashMap::new();
+
+        // Store price levels as JSON string
+        if !mm_level.levels.is_empty() {
+            let levels_json = serde_json::to_string(&mm_level.levels).unwrap_or_default();
+            attributes.insert("levels".to_string(), levels_json.as_bytes().to_vec().into());
+        }
+        attributes.insert("mm".to_string(), mm_name.as_bytes().to_vec().into());
+
+        ComponentWithState {
+            state: ResponseProtocolState {
+                component_id: component_id.clone(),
+                attributes,
+                balances: HashMap::new(),
+            },
+            component: protocol_component,
+            component_tvl: Some(tvl),
+            entrypoints: vec![],
+        }
+    }
+
+    async fn fetch_market_makers(&mut self) -> Result<(), RFQError> {
+        let query_params = vec![
+            ("source", self.source.clone()),
+            ("baseChainType", "evm".to_string()),
+            ("baseChainId", self.chain_id.to_string()),
+        ];
+
+        let request = self
+            .http_client
+            .get(&self.market_makers_endpoint)
+            .query(&query_params)
+            .header("accept", "application/json")
+            .header("Authorization", &self.auth_key);
+
+        let response = request.send().await.map_err(|e| {
+            RFQError::ConnectionError(format!("Failed to fetch market makers: {e}"))
+        })?;
+
+        if !response.status().is_success() {
+            return Err(RFQError::ConnectionError(format!(
+                "HTTP error {}: {}",
+                response.status(),
+                response
+                    .text()
+                    .await
+                    .unwrap_or_default()
+            )));
+        }
+
+        let mm_response: HashflowMarketMakersResponse = response.json().await.map_err(|e| {
+            RFQError::ParsingError(format!("Failed to parse market makers response: {e}"))
+        })?;
+
+        self.market_makers = mm_response.market_makers;
+
+        info!("Fetched {} market makers: {:?}", self.market_makers.len(), self.market_makers);
+
+        Ok(())
+    }
+
+    async fn fetch_price_levels(
+        &self,
+    ) -> Result<HashMap<String, Vec<HashflowMarketMakerLevel>>, RFQError> {
+        let mut query_params = vec![
+            ("source", self.source.clone()),
+            ("baseChainType", "evm".to_string()),
+            ("baseChainId", self.chain_id.to_string()),
+        ];
+
+        // Add market makers as array parameters
+        for mm in &self.market_makers {
+            query_params.push(("marketMakers[]", mm.clone()));
+        }
+
+        let request = self
+            .http_client
+            .get(&self.price_levels_endpoint)
+            .query(&query_params)
+            .header("accept", "application/json")
+            .header("Authorization", &self.auth_key);
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| RFQError::ConnectionError(format!("Failed to fetch price levels: {e}")))?;
+
+        if !response.status().is_success() {
+            return Err(RFQError::ConnectionError(format!(
+                "HTTP error {}: {}",
+                response.status(),
+                response
+                    .text()
+                    .await
+                    .unwrap_or_default()
+            )));
+        }
+
+        let price_response: HashflowPriceLevelsResponse = response.json().await.map_err(|e| {
+            RFQError::ParsingError(format!("Failed to parse price levels response: {e}"))
+        })?;
+
+        if price_response.status != "success" {
+            return Err(RFQError::InvalidInput(format!(
+                "API returned error status: {}",
+                price_response.error.unwrap_or_default()
+            )));
+        }
+
+        price_response
+            .levels
+            .ok_or_else(|| RFQError::ParsingError("API response missing levels".to_string()))
+    }
+}
+
+#[async_trait]
+impl RFQClient for HashflowClient {
+    fn stream(
+        &self,
+    ) -> BoxStream<'static, Result<(String, StateSyncMessage<TimestampHeader>), RFQError>> {
+        let mut client = self.clone();
+
+        Box::pin(async_stream::stream! {
+            let mut current_components: HashMap<String, ComponentWithState> = HashMap::new();
+            let mut ticker = interval(Duration::from_secs(10));
+            let mut market_makers_fetched = false;
+
+            info!("Starting Hashflow price levels polling every 10 seconds");
+            info!("TVL threshold: {:.2}", client.tvl);
+
+            loop {
+                ticker.tick().await;
+                // Fetch market makers on first iteration
+                if !market_makers_fetched {
+                    match client.fetch_market_makers().await {
+                        Ok(()) => {
+                            market_makers_fetched = true;
+                            info!("Successfully fetched market makers");
+                        }
+                        Err(e) => {
+                            error!("Failed to fetch market makers: {}", e);
+                            continue;
+                        }
+                    }
+                }
+
+                match client.fetch_price_levels().await {
+                    Ok(levels_by_mm) => {
+                        let mut new_components = HashMap::new();
+
+                        info!("Fetched price levels from {} market makers", levels_by_mm.len());
+                        // Process all market maker levels
+                        for (mm_name, mm_levels) in levels_by_mm.iter() {
+                            for mm_level in mm_levels {
+                                let base_token = &mm_level.pair.base_token;
+                                let quote_token = &mm_level.pair.quote_token;
+
+                                // Check if both tokens are in our tokens set
+                                if client.tokens.contains(base_token) && client.tokens.contains(quote_token) {
+                                    let tokens = vec![base_token.clone(), quote_token.clone()];
+                                    let tvl = mm_level.calculate_tvl();
+
+                                    // Apply TVL normalization if needed
+                                    let normalized_tvl = client.normalize_tvl(
+                                        tvl,
+                                        mm_level.pair.quote_token.clone(),
+                                        &levels_by_mm,
+                                    )?;
+
+                                    // Hash the pair for component id
+                                    let pair_str = format!("{}/{}", hex::encode(base_token), hex::encode(quote_token));
+                                    let component_id = format!("{}", keccak256(pair_str.as_bytes()));
+
+                                    if normalized_tvl < client.tvl {
+                                        info!("Filtering out component {} due to low TVL: {:.2} < {:.2}",
+                                              component_id, normalized_tvl, client.tvl);
+                                        continue;
+                                    }
+
+                                    let component_with_state = client.create_component_with_state(
+                                        component_id.clone(),
+                                        tokens,
+                                        mm_name,
+                                        mm_level,
+                                        normalized_tvl
+                                    );
+                                    new_components.insert(component_id, component_with_state);
+                                }
+                            }
+                        }
+
+                        // Find components that were removed
+                        let removed_components: HashMap<String, ProtocolComponent> = current_components
+                            .iter()
+                            .filter(|&(id, _)| !new_components.contains_key(id))
+                            .map(|(k, v)| (k.clone(), v.component.clone()))
+                            .collect();
+
+                        // Update current state
+                        current_components = new_components.clone();
+
+                        let snapshot = Snapshot {
+                            states: new_components,
+                            vm_storage: HashMap::new(),
+                        };
+                        let timestamp = SystemTime::now().duration_since(
+                            SystemTime::UNIX_EPOCH
+                        ).map_err(
+                            |_| RFQError::ParsingError("SystemTime before UNIX EPOCH!".into())
+                        )?.as_secs();
+
+                        let msg = StateSyncMessage::<TimestampHeader> {
+                            header: TimestampHeader { timestamp },
+                            snapshots: snapshot,
+                            deltas: None,
+                            removed_components,
+                        };
+
+                        yield Ok(("hashflow".to_string(), msg));
+                    },
+                    Err(e) => {
+                        error!("Failed to fetch price levels from Hashflow API: {}", e);
+                        continue;
+                    }
+                }
+            }
+        })
+    }
+
+    async fn request_binding_quote(
+        &self,
+        _params: &GetAmountOutParams,
+    ) -> Result<SignedQuote, RFQError> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{str::FromStr, time::Duration};
+
+    use futures::StreamExt;
+    use tokio::time::timeout;
+
+    use super::*;
+    use crate::rfq::protocols::hashflow::models::{HashflowPair, HashflowPriceLevel};
+
+    #[test]
+    fn test_normalize_tvl_same_quote_token() {
+        let client = create_test_client();
+        let levels = HashMap::new();
+
+        // USDC is in our quote tokens, so no normalization should happen
+        let result = client.normalize_tvl(
+            1000.0,
+            Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap(),
+            &levels,
+        );
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 1000.0);
+    }
+
+    #[test]
+    fn test_normalize_tvl_different_quote_token() {
+        let client = create_test_client();
+        let mut levels = HashMap::new();
+        let weth = Bytes::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").unwrap();
+        let usdc = Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap();
+
+        // Create mock levels for ETH/USDC pair for normalization
+        let eth_usdc_level = HashflowMarketMakerLevel {
+            pair: HashflowPair { base_token: weth.clone(), quote_token: usdc },
+            levels: vec![
+                HashflowPriceLevel { quantity: 1.0, price: 3000.0 }, /* 1 ETH = 3000 USDC */
+            ],
+        };
+
+        levels.insert("test_mm".to_string(), vec![eth_usdc_level]);
+
+        // Test normalizing ETH TVL to USDC
+        let result = client.normalize_tvl(2.0, weth, &levels);
+        assert!(result.is_ok());
+        // 2 ETH * 3000 USDC/ETH = 6000 USDC
+        assert_eq!(result.unwrap(), 6000.0);
+    }
+
+    #[test]
+    fn test_normalize_tvl_no_conversion_available() {
+        let client = create_test_client();
+        let levels = HashMap::new();
+        let result = client.normalize_tvl(
+            1000.0,
+            Bytes::from_str("0x1234567890123456789012345678901234567890").unwrap(),
+            &levels,
+        );
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 0.0);
+    }
+
+    fn create_test_client() -> HashflowClient {
+        let quote_tokens = HashSet::from([
+            Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap(), // USDC
+            Bytes::from_str("0xdAC17F958D2ee523a2206206994597C13D831ec7").unwrap(), // USDT
+        ]);
+
+        HashflowClient::new(
+            Chain::Ethereum,
+            HashSet::new(),
+            1.0,
+            quote_tokens,
+            "test_key".to_string(),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    #[ignore] // Requires network access and HASHFLOW_KEY environment variable
+    async fn test_hashflow_api_polling() {
+        use std::env;
+        let hashflow_key = env::var("HASHFLOW_KEY").unwrap();
+
+        let lpt = Bytes::from_str("0x58b6a8a3302369daec383334672404ee733ab239").unwrap();
+        let usdc = Bytes::from_str("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap();
+
+        let tokens = HashSet::from([lpt, usdc.clone()]);
+
+        let quote_tokens = HashSet::from([
+            Bytes::from_str("0xa0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap(), // USDC
+            Bytes::from_str("0xdac17f958d2ee523a2206206994597c13d831ec7").unwrap(), // USDT
+        ]);
+
+        let client = HashflowClient::new(
+            Chain::Ethereum,
+            tokens,
+            1.0, // $1 minimum TVL - very low to capture most pairs
+            quote_tokens,
+            hashflow_key,
+        )
+        .unwrap();
+
+        let mut stream = client.stream();
+
+        let result = timeout(Duration::from_secs(30), async {
+            let mut message_count = 0;
+            let max_messages = 3;
+            let mut total_components_received = 0;
+
+            while let Some(result) = stream.next().await {
+                match result {
+                    Ok((component_id, msg)) => {
+                        println!("Received message with ID: {component_id}");
+
+                        assert!(!component_id.is_empty());
+                        assert_eq!(component_id, "hashflow");
+                        assert!(msg.header.timestamp > 0);
+
+                        let snapshot = &msg.snapshots;
+                        total_components_received += snapshot.states.len();
+
+                        println!("Received {} components in this message (Total so far: {})", 
+                                snapshot.states.len(), total_components_received);
+
+                        for (id, component_with_state) in &snapshot.states {
+                            let attributes = &component_with_state.state.attributes;
+
+                            // Check that levels exist
+                            if attributes.contains_key("levels") {
+                                assert!(!attributes["levels"].is_empty());
+                            }
+                            // Check that mm name exist
+                            if attributes.contains_key("mm") {
+                                assert!(!attributes["mm"].is_empty());
+                                println!("MM name: {}:", attributes["mm"]);
+                            }
+
+                            if let Some(tvl) = component_with_state.component_tvl {
+                                assert!(tvl >= 1.0);
+                                println!("Component {id} TVL: ${tvl:.2}");
+                            }
+                        }
+
+                        message_count += 1;
+                        if message_count >= max_messages {
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        panic!("Stream error: {e}");
+                    }
+                }
+            }
+
+            assert!(message_count > 0, "Should have received at least one message");
+            assert!(total_components_received >= 1, "Should have received at least 1 component with $1 TVL threshold");
+            println!("Successfully received {message_count} messages with {total_components_received} total components");
+        })
+        .await;
+
+        match result {
+            Ok(_) => println!("Test completed successfully"),
+            Err(_) => panic!("Test timed out - no messages received within 30 seconds"),
+        }
+    }
+}

--- a/src/rfq/protocols/hashflow/mod.rs
+++ b/src/rfq/protocols/hashflow/mod.rs
@@ -1,0 +1,2 @@
+pub mod client;
+mod models;

--- a/src/rfq/protocols/hashflow/models.rs
+++ b/src/rfq/protocols/hashflow/models.rs
@@ -7,12 +7,12 @@ use tycho_common::Bytes;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HashflowPriceLevelsResponse {
     pub status: String, // "success" or "fail"
-    pub levels: Option<HashMap<String, Vec<HashflowMarketMakerLevel>>>,
+    pub levels: Option<HashMap<String, Vec<HashflowMarketMakerLevels>>>,
     pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HashflowMarketMakerLevel {
+pub struct HashflowMarketMakerLevels {
     pub pair: HashflowPair,
     pub levels: Vec<HashflowPriceLevel>,
 }
@@ -55,7 +55,7 @@ where
         .map_err(serde::de::Error::custom)
 }
 
-impl HashflowMarketMakerLevel {
+impl HashflowMarketMakerLevels {
     /// Calculate Total Value Locked (TVL) for this market maker level
     pub fn calculate_tvl(&self) -> f64 {
         self.levels
@@ -130,8 +130,8 @@ pub struct HashflowMarketMakersResponse {
 mod tests {
     use super::*;
 
-    fn hashflow_level() -> HashflowMarketMakerLevel {
-        HashflowMarketMakerLevel {
+    fn hashflow_level() -> HashflowMarketMakerLevels {
+        HashflowMarketMakerLevels {
             pair: HashflowPair {
                 base_token: Bytes::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").unwrap(),
                 quote_token: Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap(),
@@ -167,7 +167,7 @@ mod tests {
         assert_eq!(multi_level_price, Some(2999.5));
 
         // Test empty levels
-        let empty_mm_level = HashflowMarketMakerLevel {
+        let empty_mm_level = HashflowMarketMakerLevels {
             pair: HashflowPair {
                 base_token: Bytes::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").unwrap(),
                 quote_token: Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap(),

--- a/src/rfq/protocols/hashflow/models.rs
+++ b/src/rfq/protocols/hashflow/models.rs
@@ -76,8 +76,7 @@ impl HashflowMarketMakerLevels {
     /// # Returns
     /// Estimated price based on available liquidity
     pub fn get_price(&self, base_token_amount: f64) -> Option<f64> {
-        // For Hashflow, we don't have separate bid/ask levels
-        // We treat all levels as available liquidity regardless of direction
+        // We treat all levels as available liquidity regardless of sell/buy direction
         if self.levels.is_empty() {
             return None;
         }

--- a/src/rfq/protocols/hashflow/models.rs
+++ b/src/rfq/protocols/hashflow/models.rs
@@ -1,0 +1,199 @@
+use std::{collections::HashMap, str::FromStr};
+
+use alloy::primitives::Address;
+use serde::{Deserialize, Serialize};
+use tycho_common::Bytes;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HashflowPriceLevelsResponse {
+    pub status: String, // "success" or "fail"
+    pub levels: Option<HashMap<String, Vec<HashflowMarketMakerLevel>>>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HashflowMarketMakerLevel {
+    pub pair: HashflowPair,
+    pub levels: Vec<HashflowPriceLevel>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HashflowPair {
+    #[serde(rename = "baseToken", deserialize_with = "deserialize_string_to_checksummed_bytes")]
+    pub base_token: Bytes,
+    #[serde(rename = "quoteToken", deserialize_with = "deserialize_string_to_checksummed_bytes")]
+    pub quote_token: Bytes,
+}
+
+fn deserialize_string_to_checksummed_bytes<'de, D>(deserializer: D) -> Result<Bytes, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    let address = Address::from_str(&s).map_err(serde::de::Error::custom)?;
+    let checksum = address.to_checksum(None);
+    let checksum_bytes = Bytes::from_str(&checksum).map_err(serde::de::Error::custom)?;
+    Ok(checksum_bytes)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HashflowPriceLevel {
+    #[serde(rename = "q", deserialize_with = "deserialize_string_to_f64")]
+    /// Quantity of tokens that can be traded at this level
+    pub quantity: f64,
+    #[serde(rename = "p", deserialize_with = "deserialize_string_to_f64")]
+    /// Price per token at this level
+    pub price: f64,
+}
+
+fn deserialize_string_to_f64<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    s.parse()
+        .map_err(serde::de::Error::custom)
+}
+
+impl HashflowMarketMakerLevel {
+    /// Calculate Total Value Locked (TVL) for this market maker level
+    pub fn calculate_tvl(&self) -> f64 {
+        self.levels
+            .iter()
+            .map(|level| level.quantity * level.price)
+            .sum()
+    }
+
+    /// Calculate quote token amount for trading base tokens using price levels
+    ///
+    /// NOTE: This method is meant just to be used as an estimate - as it does not
+    /// error or return None if there is not enough liquidity to cover base token amount.
+    /// This method will only return None if there are absolutely no price levels.
+    ///
+    /// # Parameters
+    /// - `base_token_amount`: The amount of tokens to trade
+    ///
+    /// # Returns
+    /// Estimated price based on available liquidity
+    pub fn get_price(&self, base_token_amount: f64) -> Option<f64> {
+        // For Hashflow, we don't have separate bid/ask levels
+        // We treat all levels as available liquidity regardless of direction
+        if self.levels.is_empty() {
+            return None;
+        }
+
+        let (total_quote_token, remaining_base_token) =
+            self.get_amount_out_from_levels(base_token_amount);
+
+        // If we can't fill the whole order (ran out of liquidity), calculate the price based on
+        // the amount that we could fill, in order to have at least some price estimate
+        Some(total_quote_token / (base_token_amount - remaining_base_token))
+    }
+
+    /// Calculates the total token output for a given token input using available price levels.
+    ///
+    /// Iterates over the price levels, consuming as much liquidity as available at each
+    /// price level until the input amount is fully consumed or liquidity runs out.
+    ///
+    /// # Parameters
+    /// - `amount_in`: The amount of base tokens to trade.
+    ///
+    /// # Returns
+    /// A tuple of (amount_out, remaining_amount_in) where:
+    /// - `amount_out`: The total quote tokens that can be obtained
+    /// - `remaining_amount_in`: Any remaining base tokens that couldn't be filled
+    fn get_amount_out_from_levels(&self, amount_in: f64) -> (f64, f64) {
+        let mut remaining_amount_in = amount_in;
+        let mut total_amount_out = 0.0;
+
+        for level in &self.levels {
+            if remaining_amount_in <= 0.0 {
+                break;
+            };
+
+            let amount_to_fill = remaining_amount_in.min(level.quantity);
+            total_amount_out += amount_to_fill * level.price;
+            remaining_amount_in -= amount_to_fill;
+        }
+
+        (total_amount_out, remaining_amount_in)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HashflowMarketMakersResponse {
+    #[serde(rename = "marketMakers")]
+    pub market_makers: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hashflow_level() -> HashflowMarketMakerLevel {
+        HashflowMarketMakerLevel {
+            pair: HashflowPair {
+                base_token: Bytes::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").unwrap(),
+                quote_token: Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap(),
+            },
+            levels: vec![
+                HashflowPriceLevel { quantity: 1.0, price: 3000.0 },
+                HashflowPriceLevel { quantity: 2.0, price: 2999.0 },
+            ],
+        }
+    }
+
+    #[test]
+    fn test_market_maker_level_tvl() {
+        let mm_level = hashflow_level();
+
+        let tvl = mm_level.calculate_tvl();
+        // 1.0 * 3000.0 + 2.0 * 2999.0 = 3000.0 + 5998.0 = 8998.0
+        assert_eq!(tvl, 8998.0);
+    }
+
+    #[test]
+    fn test_get_price() {
+        let mm_level = hashflow_level();
+
+        // Test single-level price
+        let price = mm_level.get_price(1.0);
+        assert_eq!(price, Some(3000.0));
+
+        // Test larger amount spanning multiple levels
+        let multi_level_price = mm_level.get_price(2.0);
+        // 1.0 * 3000.0 + 1.0 * 2999.0 = 5999.0 total
+        // 5999.0 / 2.0 = 2999.5
+        assert_eq!(multi_level_price, Some(2999.5));
+
+        // Test empty levels
+        let empty_mm_level = HashflowMarketMakerLevel {
+            pair: HashflowPair {
+                base_token: Bytes::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").unwrap(),
+                quote_token: Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap(),
+            },
+            levels: vec![],
+        };
+        assert_eq!(empty_mm_level.get_price(1.0), None);
+    }
+
+    #[test]
+    fn test_get_amount_out_from_levels() {
+        let mm_level = hashflow_level();
+
+        // Test exact amount that can be filled with a single level
+        let (amount_out, remaining) = mm_level.get_amount_out_from_levels(1.0);
+        assert_eq!(amount_out, 3000.0); // 1.0 * 3000.0
+        assert_eq!(remaining, 0.0);
+
+        // Test amount spanning multiple levels
+        let (amount_out, remaining) = mm_level.get_amount_out_from_levels(2.0);
+        assert_eq!(amount_out, 5999.0); // 1.0 * 3000.0 + 1.0 * 2999.0
+        assert_eq!(remaining, 0.0);
+
+        // Test amount exceeding available liquidity
+        let (amount_out, remaining) = mm_level.get_amount_out_from_levels(5.0);
+        assert_eq!(amount_out, 8998.0); // 1.0 * 3000.0 + 2.0 * 2999.0 = 3000.0 + 5998.0
+        assert_eq!(remaining, 2.0); // 5.0 - 3.0 (total available)
+    }
+}

--- a/src/rfq/protocols/mod.rs
+++ b/src/rfq/protocols/mod.rs
@@ -1,1 +1,2 @@
 pub mod bebop;
+pub mod hashflow;


### PR DESCRIPTION
- Fetches mms from Hashflow API
- Passes them to the price levels API
- Normalizes all prices against the approved quote tokens (only to filter for TVL).
- Returns components for each token pair and mm.