### PR TITLE
feat: get_limits for USV4 if no liquidity

### DIFF
--- a/src/evm/protocol/uniswap_v4/state.rs
+++ b/src/evm/protocol/uniswap_v4/state.rs
@@ -545,7 +545,7 @@ impl ProtocolSim for UniswapV4State {
                 match hook.get_amount_ranges(token_in.clone(), token_out.clone()) {
                     Ok(amount_ranges) => {
                         return Ok((
-                            BigUint::from(0u8),
+                            u256_to_biguint(amount_ranges.amount_in_range.1),
                             u256_to_biguint(amount_ranges.amount_out_range.1),
                         ))
                     }

--- a/src/evm/protocol/utils/uniswap/tick_list.rs
+++ b/src/evm/protocol/utils/uniswap/tick_list.rs
@@ -162,6 +162,23 @@ impl TickList {
         }
     }
 
+    pub(crate) fn has_initialized_ticks(&self) -> bool {
+        // If the tick list is empty, there are no initialized ticks
+        if self.ticks.is_empty() {
+            return false;
+        }
+
+        // Check if any ticks have non-zero net liquidity (are initialized)
+        for tick_info in &self.ticks {
+            if tick_info.net_liquidity != 0 {
+                return true;
+            }
+        }
+
+        // All ticks have zero net liquidity, so no initialized ticks
+        false
+    }
+
     fn next_initialized_tick(&self, index: i32, lte: bool) -> Result<&TickInfo, TickListError> {
         if lte {
             if self.is_below_smallest(index) {


### PR DESCRIPTION
Please refer to the [task](https://propeller-heads.atlassian.net/jira/software/projects/ENG/boards/24?jql=&selectedIssue=ENG-4740).

`find_max_amount` uses exponential search: https://en.wikipedia.org/wiki/Exponential_search

Exponential search is likely much faster than binary search for our use case:
 - `get_amount_out(I256::MAX)` will almost always fail, so this will waste time checking values unrealistically high.
 - If you were to start binary search from 1 to 10^76, you'd need hundreds of iterations.