### PR TITLE
feat: Hashflow decoder

### DIFF
--- a/examples/rfq_quickstart/main.rs
+++ b/examples/rfq_quickstart/main.rs
@@ -78,11 +78,11 @@ async fn main() {
     let tycho_api_key: String =
         env::var("TYCHO_API_KEY").unwrap_or_else(|_| "sampletoken".to_string());
 
-    // Get WebSocket credentials for any RFQ(s) we are using
-    let bebop_ws_user = env::var("BEBOP_WS_USER")
-        .expect("BEBOP_WS_USER environment variable is required. Contact Bebop for credentials.");
-    let bebop_ws_key = env::var("BEBOP_WS_KEY")
-        .expect("BEBOP_WS_KEY environment variable is required. Contact Bebop for credentials.");
+    // Get credentials for any RFQ(s) we are using
+    let bebop_ws_user = env::var("BEBOP_USER")
+        .expect("BEBOP_USER environment variable is required. Contact Bebop for credentials.");
+    let bebop_ws_key = env::var("BEBOP_KEY")
+        .expect("BEBOP_KEY environment variable is required. Contact Bebop for credentials.");
 
     println!("Loading tokens from Tycho... {url}", url = tycho_url.as_str());
     let all_tokens =

--- a/src/evm/protocol/uniswap_v4/hooks/generic_vm_hook_handler.rs
+++ b/src/evm/protocol/uniswap_v4/hooks/generic_vm_hook_handler.rs
@@ -463,6 +463,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // Rate limits on Unichain RPC free tier
     fn test_before_and_after_swap() {
         let block = BlockHeader {
             number: 15797251,

--- a/src/rfq/constants.rs
+++ b/src/rfq/constants.rs
@@ -1,0 +1,119 @@
+use std::env;
+
+use crate::rfq::errors::RFQError;
+
+/// Hashflow authentication configuration
+pub struct HashflowAuth {
+    pub user: String,
+    pub key: String,
+}
+
+/// Bebop authentication configuration
+pub struct BebopAuth {
+    pub user: String,
+    pub key: String,
+}
+
+/// Read Hashflow authentication from environment variables
+/// Returns the HASHFLOW_USER and HASHFLOW_KEY environment variables
+pub fn get_hashflow_auth() -> Result<HashflowAuth, RFQError> {
+    let user = env::var("HASHFLOW_USER").map_err(|_| {
+        RFQError::InvalidInput("HASHFLOW_USER environment variable is required".into())
+    })?;
+
+    let key = env::var("HASHFLOW_KEY").map_err(|_| {
+        RFQError::InvalidInput("HASHFLOW_KEY environment variable is required".into())
+    })?;
+
+    Ok(HashflowAuth { user, key })
+}
+
+/// Read Bebop authentication from environment variables
+/// Returns the BEBOP_USER and BEBOP_KEY environment variables
+pub fn get_bebop_auth() -> Result<BebopAuth, RFQError> {
+    let user = env::var("BEBOP_USER").map_err(|_| {
+        RFQError::InvalidInput("BEBOP_USER environment variable is required".into())
+    })?;
+
+    let key = env::var("BEBOP_KEY")
+        .map_err(|_| RFQError::InvalidInput("BEBOP_KEY environment variable is required".into()))?;
+
+    Ok(BebopAuth { user, key })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+
+    use super::*;
+
+    #[test]
+    fn test_hashflow_auth_success() {
+        env::set_var("HASHFLOW_USER", "test_user");
+        env::set_var("HASHFLOW_KEY", "test_key");
+
+        let auth = get_hashflow_auth().unwrap();
+        assert_eq!(auth.user, "test_user");
+        assert_eq!(auth.key, "test_key");
+
+        env::remove_var("HASHFLOW_USER");
+        env::remove_var("HASHFLOW_KEY");
+    }
+
+    #[test]
+    fn test_hashflow_auth_missing_user() {
+        env::remove_var("HASHFLOW_USER");
+        env::set_var("HASHFLOW_KEY", "test_key");
+
+        let result = get_hashflow_auth();
+        assert!(result.is_err());
+
+        env::remove_var("HASHFLOW_KEY");
+    }
+
+    #[test]
+    fn test_hashflow_auth_missing_key() {
+        env::set_var("HASHFLOW_USER", "test_user");
+        env::remove_var("HASHFLOW_KEY");
+
+        let result = get_hashflow_auth();
+        assert!(result.is_err());
+
+        env::remove_var("HASHFLOW_USER");
+    }
+
+    #[test]
+    fn test_bebop_auth_success() {
+        env::set_var("BEBOP_USER", "test_user");
+        env::set_var("BEBOP_KEY", "test_key");
+
+        let auth = get_bebop_auth().unwrap();
+        assert_eq!(auth.user, "test_user");
+        assert_eq!(auth.key, "test_key");
+
+        env::remove_var("BEBOP_USER");
+        env::remove_var("BEBOP_KEY");
+    }
+
+    #[test]
+    fn test_bebop_auth_missing_user() {
+        env::remove_var("BEBOP_USER");
+        env::set_var("BEBOP_KEY", "test_key");
+
+        let result = get_bebop_auth();
+        assert!(result.is_err());
+
+        env::remove_var("BEBOP_KEY");
+    }
+
+    #[test]
+    fn test_bebop_auth_missing_key() {
+        env::set_var("BEBOP_USER", "test_user");
+        env::remove_var("BEBOP_KEY");
+
+        let result = get_bebop_auth();
+        assert!(result.is_err());
+
+        env::remove_var("BEBOP_USER");
+    }
+}

--- a/src/rfq/mod.rs
+++ b/src/rfq/mod.rs
@@ -1,4 +1,5 @@
 pub mod client;
+pub mod constants;
 pub mod errors;
 pub mod models;
 pub mod protocols;

--- a/src/rfq/protocols/bebop/client.rs
+++ b/src/rfq/protocols/bebop/client.rs
@@ -699,8 +699,7 @@ mod tests {
         };
         let ws_user = String::from("tycho");
         dotenv().expect("Missing .env file");
-        let ws_key =
-            env::var("BEBOP_WS_KEY").expect("BEBOP_WS_KEY environment variable is required");
+        let ws_key = env::var("BEBOP_KEY").expect("BEBOP_KEY environment variable is required");
 
         let client = BebopClient::new(
             Chain::Ethereum,

--- a/src/rfq/protocols/bebop/client.rs
+++ b/src/rfq/protocols/bebop/client.rs
@@ -455,7 +455,6 @@ impl RFQClient for BebopClient {
 #[cfg(test)]
 mod tests {
     use std::{
-        env,
         sync::{Arc, Mutex},
         time::Duration,
     };
@@ -467,6 +466,7 @@ mod tests {
     use tycho_common::models::token::Token;
 
     use super::*;
+    use crate::rfq::constants::get_bebop_auth;
 
     #[tokio::test]
     #[ignore] // Requires network access and setting proper env vars
@@ -476,9 +476,8 @@ mod tests {
         let wbtc = Bytes::from_str("0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599").unwrap();
         let weth = Bytes::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").unwrap();
 
-        let ws_user = String::from("tycho");
         dotenv().expect("Missing .env file");
-        let ws_key = env::var("BEBOP_KEY").expect("BEBOP_KEY environment variable is required");
+        let auth = get_bebop_auth().expect("Failed to get Bebop authentication");
 
         let quote_tokens = HashSet::from([
             // Use addresses we forgot to checksum (to test checksumming)
@@ -490,8 +489,8 @@ mod tests {
             Chain::Ethereum,
             HashSet::from_iter(vec![weth.clone(), wbtc.clone()]),
             10.0, // $10 minimum TVL
-            ws_user,
-            ws_key,
+            auth.user,
+            auth.key,
             quote_tokens,
         )
         .unwrap();
@@ -737,16 +736,15 @@ mod tests {
             chain: Default::default(),
             quality: 100,
         };
-        let ws_user = String::from("tycho");
         dotenv().expect("Missing .env file");
-        let ws_key = env::var("BEBOP_KEY").expect("BEBOP_KEY environment variable is required");
+        let auth = get_bebop_auth().expect("Failed to get Bebop authentication");
 
         let client = BebopClient::new(
             Chain::Ethereum,
             HashSet::from_iter(vec![token_in.address.clone(), token_out.address.clone()]),
             10.0, // $10 minimum TVL
-            ws_user,
-            ws_key,
+            auth.user,
+            auth.key,
             HashSet::new(),
         )
         .unwrap();
@@ -816,17 +814,15 @@ mod tests {
             chain: Default::default(),
             quality: 100,
         };
-        let ws_user = String::from("tycho");
         dotenv().expect("Missing .env file");
-        let ws_key =
-            env::var("BEBOP_WS_KEY").expect("BEBOP_WS_KEY environment variable is required");
+        let auth = get_bebop_auth().expect("Failed to get Bebop authentication");
 
         let client = BebopClient::new(
             Chain::Ethereum,
             HashSet::from_iter(vec![token_in.address.clone(), token_out.address.clone()]),
             10.0, // $10 minimum TVL
-            ws_user,
-            ws_key,
+            auth.user,
+            auth.key,
             HashSet::new(),
         )
         .unwrap();

--- a/src/rfq/protocols/bebop/client.rs
+++ b/src/rfq/protocols/bebop/client.rs
@@ -248,7 +248,7 @@ impl RFQClient for BebopClient {
                                                 continue;
                                             }
 
-                                            let pair_str = format!("{}/{}", hex::encode(&base_bytes), hex::encode(&quote_bytes));
+                                            let pair_str = format!("bebop_{}/{}", hex::encode(&base_bytes), hex::encode(&quote_bytes));
                                             let component_id = format!("{}", keccak256(pair_str.as_bytes()));
                                             let component_with_state = client.create_component_with_state(
                                                 component_id.clone(),

--- a/src/rfq/protocols/bebop/client_builder.rs
+++ b/src/rfq/protocols/bebop/client_builder.rs
@@ -91,11 +91,6 @@ impl BebopClientBuilder {
     }
 
     pub fn build(self) -> Result<BebopClient, RFQError> {
-        if self.tokens.is_empty() {
-            return Err(RFQError::InvalidInput(
-                "At least one token pair must be specified".to_string(),
-            ));
-        }
         let quote_tokens;
         if let Some(tokens) = self.quote_tokens {
             quote_tokens = tokens;
@@ -147,18 +142,5 @@ mod tests {
         .quote_tokens(custom_quote_tokens.clone())
         .build();
         assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_bebop_client_builder_validation() {
-        let result = BebopClientBuilder::new(
-            Chain::Ethereum,
-            "test_user".to_string(),
-            "test_key".to_string(),
-        )
-        .build();
-
-        assert!(result.is_err());
-        assert!(matches!(result, Err(RFQError::InvalidInput(_))), "Wrong error.");
     }
 }

--- a/src/rfq/protocols/hashflow/client.rs
+++ b/src/rfq/protocols/hashflow/client.rs
@@ -299,7 +299,7 @@ impl RFQClient for HashflowClient {
                                     )?;
 
                                     // Hash the pair for component id
-                                    let pair_str = format!("{}/{}", hex::encode(base_token), hex::encode(quote_token));
+                                    let pair_str = format!("hashflow_{}/{}", hex::encode(base_token), hex::encode(quote_token));
                                     let component_id = format!("{}", keccak256(pair_str.as_bytes()));
 
                                     if normalized_tvl < client.tvl {

--- a/src/rfq/protocols/hashflow/client.rs
+++ b/src/rfq/protocols/hashflow/client.rs
@@ -132,6 +132,7 @@ impl HashflowClient {
         // Store price levels as JSON string
         if !mm_level.levels.is_empty() {
             let levels_json = serde_json::to_string(&mm_level.levels).unwrap_or_default();
+            println!("{levels_json:?}");
             attributes.insert("levels".to_string(), levels_json.as_bytes().to_vec().into());
         }
         attributes.insert("mm".to_string(), mm_name.as_bytes().to_vec().into());
@@ -592,10 +593,10 @@ mod tests {
         dotenv().expect("Missing .env file");
         let hashflow_key = env::var("HASHFLOW_KEY").unwrap();
 
-        let lpt = Bytes::from_str("0x58b6a8a3302369daec383334672404ee733ab239").unwrap();
-        let usdc = Bytes::from_str("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48").unwrap();
+        let wbtc = Bytes::from_str("0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599").unwrap();
+        let weth = Bytes::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").unwrap();
 
-        let tokens = HashSet::from([lpt, usdc.clone()]);
+        let tokens = HashSet::from([wbtc, weth.clone()]);
 
         let quote_tokens = HashSet::from([
             Bytes::from_str("0xa0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap(), // USDC
@@ -615,7 +616,7 @@ mod tests {
 
         let mut stream = client.stream();
 
-        let result = timeout(Duration::from_secs(5), async {
+        let result = timeout(Duration::from_secs(10), async {
             let mut message_count = 0;
             let max_messages = 3;
             let mut total_components_received = 0;
@@ -637,9 +638,10 @@ mod tests {
 
                         for (id, component_with_state) in &snapshot.states {
                             let attributes = &component_with_state.state.attributes;
-
+                            let levels: &Bytes = attributes.get("levels").unwrap();
                             // Check that levels exist
                             if attributes.contains_key("levels") {
+                                println!("{levels:?}");
                                 assert!(!attributes["levels"].is_empty());
                             }
                             // Check that mm name exist

--- a/src/rfq/protocols/hashflow/client.rs
+++ b/src/rfq/protocols/hashflow/client.rs
@@ -132,7 +132,6 @@ impl HashflowClient {
         // Store price levels as JSON string
         if !mm_level.levels.is_empty() {
             let levels_json = serde_json::to_string(&mm_level.levels).unwrap_or_default();
-            println!("{levels_json:?}");
             attributes.insert("levels".to_string(), levels_json.as_bytes().to_vec().into());
         }
         attributes.insert("mm".to_string(), mm_name.as_bytes().to_vec().into());
@@ -515,7 +514,10 @@ mod tests {
     use tycho_common::models::token::Token;
 
     use super::*;
-    use crate::rfq::protocols::hashflow::models::{HashflowPair, HashflowPriceLevel};
+    use crate::rfq::{
+        constants::get_hashflow_auth,
+        protocols::hashflow::models::{HashflowPair, HashflowPriceLevel},
+    };
 
     #[test]
     fn test_normalize_tvl_same_quote_token() {
@@ -591,7 +593,7 @@ mod tests {
     #[ignore] // Requires network access and HASHFLOW_KEY environment variable
     async fn test_hashflow_api_polling() {
         dotenv().expect("Missing .env file");
-        let hashflow_key = env::var("HASHFLOW_KEY").unwrap();
+        let auth = get_hashflow_auth().unwrap();
 
         let wbtc = Bytes::from_str("0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599").unwrap();
         let weth = Bytes::from_str("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").unwrap();
@@ -608,8 +610,8 @@ mod tests {
             tokens,
             1.0, // $1 minimum TVL - very low to capture most pairs
             quote_tokens,
-            "propellerheads".to_string(),
-            hashflow_key,
+            auth.user,
+            auth.key,
             1,
         )
         .unwrap();

--- a/src/rfq/protocols/hashflow/mod.rs
+++ b/src/rfq/protocols/hashflow/mod.rs
@@ -1,3 +1,4 @@
 pub mod client;
 mod models;
 mod state;
+pub mod tycho_decoder;

--- a/src/rfq/protocols/hashflow/state.rs
+++ b/src/rfq/protocols/hashflow/state.rs
@@ -24,6 +24,8 @@ pub struct HashflowState {
     pub base_token: Token,
     pub quote_token: Token,
     pub levels: HashflowMarketMakerLevels,
+    #[allow(dead_code)]
+    pub market_maker: String,
     pub client: HashflowClient,
 }
 
@@ -33,9 +35,10 @@ impl HashflowState {
         base_token: Token,
         quote_token: Token,
         levels: HashflowMarketMakerLevels,
+        market_maker: String,
         client: HashflowClient,
     ) -> Self {
-        Self { base_token, quote_token, levels, client }
+        Self { base_token, quote_token, levels, market_maker, client }
     }
 
     fn valid_direction_guard(
@@ -276,6 +279,7 @@ mod tests {
                     HashflowPriceLevel { quantity: 5.0, price: 2999.0 },
                 ],
             },
+            market_maker: "test_mm".to_string(),
             client: empty_hashflow_client(),
         }
     }

--- a/src/rfq/protocols/hashflow/tycho_decoder.rs
+++ b/src/rfq/protocols/hashflow/tycho_decoder.rs
@@ -1,0 +1,382 @@
+use std::{
+    collections::{HashMap, HashSet},
+    env,
+};
+
+use tycho_client::feed::synchronizer::ComponentWithState;
+use tycho_common::{models::token::Token, Bytes};
+
+use super::{
+    models::{HashflowMarketMakerLevels, HashflowPair, HashflowPriceLevel},
+    state::HashflowState,
+};
+use crate::{
+    protocol::{errors::InvalidSnapshotError, models::TryFromWithBlock},
+    rfq::{models::TimestampHeader, protocols::hashflow::client::HashflowClient},
+};
+
+impl TryFromWithBlock<ComponentWithState, TimestampHeader> for HashflowState {
+    type Error = InvalidSnapshotError;
+
+    async fn try_from_with_header(
+        snapshot: ComponentWithState,
+        _timestamp_header: TimestampHeader,
+        _account_balances: &HashMap<Bytes, HashMap<Bytes, Bytes>>,
+        all_tokens: &HashMap<Bytes, Token>,
+    ) -> Result<Self, Self::Error> {
+        let state_attrs = snapshot.state.attributes;
+
+        if snapshot.component.tokens.len() != 2 {
+            return Err(InvalidSnapshotError::ValueError(
+                "Component must have 2 tokens (base and quote)".to_string(),
+            ));
+        }
+
+        let base_token_address = &snapshot.component.tokens[0];
+        let quote_token_address = &snapshot.component.tokens[1];
+
+        let base_token = all_tokens
+            .get(base_token_address)
+            .ok_or_else(|| {
+                InvalidSnapshotError::ValueError(format!(
+                    "Base token not found: {base_token_address}"
+                ))
+            })?
+            .clone();
+
+        let quote_token = all_tokens
+            .get(quote_token_address)
+            .ok_or_else(|| {
+                InvalidSnapshotError::ValueError(format!(
+                    "Quote token not found: {quote_token_address}"
+                ))
+            })?
+            .clone();
+
+        // Parse the price levels array from the component attributes.
+        // A missing levels key indicates no levels for this market maker.
+        let empty_levels_array: Bytes = "[]".as_bytes().to_vec().into();
+        let levels_data = state_attrs
+            .get("levels")
+            .unwrap_or(&empty_levels_array);
+
+        let price_levels: Vec<HashflowPriceLevel> = serde_json::from_slice(levels_data)
+            .map_err(|e| InvalidSnapshotError::ValueError(format!("Invalid levels JSON: {e}")))?;
+
+        let market_maker = state_attrs
+            .get("mm")
+            .ok_or_else(|| {
+                InvalidSnapshotError::MissingAttribute("mm attribute not found".to_string())
+            })
+            .and_then(|mm_bytes| {
+                String::from_utf8(mm_bytes.to_vec()).map_err(|_| {
+                    InvalidSnapshotError::ValueError("Invalid mm encoding".to_string())
+                })
+            })?;
+
+        // Create the HashflowMarketMakerLevels using token pair from component
+        let levels = HashflowMarketMakerLevels {
+            pair: HashflowPair {
+                base_token: base_token_address.clone(),
+                quote_token: quote_token_address.clone(),
+            },
+            levels: price_levels,
+        };
+
+        // Create HashFlow client with authentication from environment variables
+        let auth_user = env::var("HASHFLOW_USER").map_err(|_| {
+            InvalidSnapshotError::ValueError(
+                "HASHFLOW_USER environment variable is required".into(),
+            )
+        })?;
+        let auth_key = env::var("HASHFLOW_KEY").map_err(|_| {
+            InvalidSnapshotError::ValueError("HASHFLOW_KEY environment variable is required".into())
+        })?;
+
+        let client = HashflowClient::new(
+            snapshot.component.chain.into(),
+            HashSet::from([base_token_address.clone(), quote_token_address.clone()]),
+            // Since we will not be polling for price levels, this value is irrelevant, since
+            // no TVL filtering will be performed.
+            0.0,
+            // Approved quote tokens can be empty, since no more normalization will be
+            // necessary inside the HashflowState
+            HashSet::new(),
+            auth_user,
+            auth_key,
+            // Since we will not be polling for price levels, this value is irrelevant
+            0u64,
+        )
+        .map_err(|e| {
+            InvalidSnapshotError::MissingAttribute(format!("Couldn't create HashflowClient: {e}"))
+        })?;
+
+        Ok(HashflowState::new(base_token, quote_token, levels, market_maker, client))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use tycho_common::{
+        dto::{Chain, ChangeType, ProtocolComponent, ResponseProtocolState},
+        models::Chain as ModelChain,
+    };
+
+    use super::*;
+
+    fn wbtc() -> Token {
+        Token::new(
+            &hex::decode("2260fac5e5542a773aa44fbcfedf7c193bc2c599")
+                .unwrap()
+                .into(),
+            "WBTC",
+            8,
+            0,
+            &[Some(10_000)],
+            ModelChain::Ethereum,
+            100,
+        )
+    }
+
+    fn usdc() -> Token {
+        Token::new(
+            &hex::decode("a0b86991c6218a76c1d19d4a2e9eb0ce3606eb48")
+                .unwrap()
+                .into(),
+            "USDC",
+            6,
+            0,
+            &[Some(10_000)],
+            ModelChain::Ethereum,
+            100,
+        )
+    }
+
+    fn create_test_levels() -> serde_json::Value {
+        serde_json::json!([
+            {
+                "q": "1.5",
+                "p": "65000.0"
+            },
+            {
+                "q": "2.0",
+                "p": "64950.0"
+            },
+            {
+                "q": "0.5",
+                "p": "65100.0"
+            }
+        ])
+    }
+
+    fn create_test_snapshot() -> (ComponentWithState, HashMap<Bytes, Token>) {
+        let wbtc_token = wbtc();
+        let usdc_token = usdc();
+        let levels = create_test_levels();
+
+        let mut tokens = HashMap::new();
+        tokens.insert(wbtc_token.address.clone(), wbtc_token.clone());
+        tokens.insert(usdc_token.address.clone(), usdc_token.clone());
+
+        let mut state_attributes = HashMap::new();
+
+        // Serialize the levels to JSON
+        let levels_json = serde_json::to_vec(&levels).expect("Failed to serialize levels");
+        state_attributes.insert("levels".to_string(), levels_json.into());
+
+        // Add market maker name
+        state_attributes.insert(
+            "mm".to_string(),
+            "test_market_maker"
+                .as_bytes()
+                .to_vec()
+                .into(),
+        );
+
+        let snapshot = ComponentWithState {
+            state: ResponseProtocolState {
+                attributes: state_attributes,
+                component_id: "hashflow_wbtc_usdc".to_string(),
+                balances: HashMap::new(),
+            },
+            component: ProtocolComponent {
+                id: "hashflow_wbtc_usdc".to_string(),
+                protocol_system: "hashflow".to_string(),
+                protocol_type_name: "hashflow".to_string(),
+                chain: Chain::Ethereum,
+                tokens: vec![wbtc_token.address.clone(), usdc_token.address.clone()],
+                contract_ids: Vec::new(),
+                static_attributes: HashMap::new(),
+                change: ChangeType::Creation,
+                creation_tx: Bytes::default(),
+                created_at: chrono::NaiveDateTime::default(),
+            },
+            component_tvl: None,
+            entrypoints: Vec::new(),
+        };
+
+        (snapshot, tokens)
+    }
+
+    #[tokio::test]
+    async fn test_try_from_with_header() {
+        env::set_var("HASHFLOW_USER", "test_user");
+        env::set_var("HASHFLOW_KEY", "test_key");
+
+        let (snapshot, tokens) = create_test_snapshot();
+
+        let result = HashflowState::try_from_with_header(
+            snapshot,
+            TimestampHeader { timestamp: 1703097600u64 },
+            &HashMap::new(),
+            &tokens,
+        )
+        .await
+        .expect("create state from snapshot");
+
+        assert_eq!(result.base_token.symbol, "WBTC");
+        assert_eq!(result.quote_token.symbol, "USDC");
+        assert_eq!(result.market_maker, "test_market_maker");
+        assert_eq!(result.levels.levels.len(), 3);
+        assert_eq!(result.levels.levels[0].quantity, 1.5);
+        assert_eq!(result.levels.levels[0].price, 65000.0);
+        assert_eq!(result.levels.levels[1].quantity, 2.0);
+        assert_eq!(result.levels.levels[1].price, 64950.0);
+        assert_eq!(result.levels.levels[2].quantity, 0.5);
+        assert_eq!(result.levels.levels[2].price, 65100.0);
+    }
+
+    #[tokio::test]
+    async fn test_try_from_missing_levels() {
+        env::set_var("HASHFLOW_USER", "test_user");
+        env::set_var("HASHFLOW_KEY", "test_key");
+
+        let (mut snapshot, tokens) = create_test_snapshot();
+        snapshot
+            .state
+            .attributes
+            .remove("levels");
+
+        let result = HashflowState::try_from_with_header(
+            snapshot,
+            TimestampHeader::default(),
+            &HashMap::new(),
+            &tokens,
+        )
+        .await
+        .expect("create state with missing levels should default to empty levels");
+
+        // Should succeed with empty levels
+        assert_eq!(result.base_token.symbol, "WBTC");
+        assert_eq!(result.quote_token.symbol, "USDC");
+        assert_eq!(result.levels.levels.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_try_from_missing_token() {
+        env::set_var("HASHFLOW_USER", "test_user");
+        env::set_var("HASHFLOW_KEY", "test_key");
+
+        // Test missing second token (only one token in array)
+        let (mut snapshot, tokens) = create_test_snapshot();
+        snapshot.component.tokens.pop(); // Remove the second token
+
+        let result = HashflowState::try_from_with_header(
+            snapshot,
+            TimestampHeader::default(),
+            &HashMap::new(),
+            &tokens,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), InvalidSnapshotError::ValueError(_)));
+    }
+
+    #[tokio::test]
+    async fn test_try_from_too_many_tokens() {
+        env::set_var("HASHFLOW_USER", "test_user");
+        env::set_var("HASHFLOW_KEY", "test_key");
+
+        // Test with three tokens instead of two
+        let (mut snapshot, mut tokens) = create_test_snapshot();
+
+        let dai_token = Token::new(
+            &hex::decode("6b175474e89094c44da98b954eedeac495271d0f")
+                .unwrap()
+                .into(),
+            "DAI",
+            18,
+            0,
+            &[Some(10_000)],
+            ModelChain::Ethereum,
+            100,
+        );
+
+        tokens.insert(dai_token.address.clone(), dai_token.clone());
+        snapshot
+            .component
+            .tokens
+            .push(dai_token.address);
+
+        let result = HashflowState::try_from_with_header(
+            snapshot,
+            TimestampHeader::default(),
+            &HashMap::new(),
+            &tokens,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), InvalidSnapshotError::ValueError(_)));
+    }
+
+    #[tokio::test]
+    async fn test_try_from_invalid_levels_json() {
+        env::set_var("HASHFLOW_USER", "test_user");
+        env::set_var("HASHFLOW_KEY", "test_key");
+
+        let (mut snapshot, tokens) = create_test_snapshot();
+
+        // Insert invalid JSON for levels
+        snapshot.state.attributes.insert(
+            "levels".to_string(),
+            "invalid json"
+                .as_bytes()
+                .to_vec()
+                .into(),
+        );
+
+        let result = HashflowState::try_from_with_header(
+            snapshot,
+            TimestampHeader::default(),
+            &HashMap::new(),
+            &tokens,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), InvalidSnapshotError::ValueError(_)));
+    }
+
+    #[tokio::test]
+    async fn test_try_from_missing_mm() {
+        env::set_var("HASHFLOW_USER", "test_user");
+        env::set_var("HASHFLOW_KEY", "test_key");
+
+        let (mut snapshot, tokens) = create_test_snapshot();
+        snapshot.state.attributes.remove("mm");
+
+        let result = HashflowState::try_from_with_header(
+            snapshot,
+            TimestampHeader::default(),
+            &HashMap::new(),
+            &tokens,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), InvalidSnapshotError::MissingAttribute(_)));
+    }
+}


### PR DESCRIPTION
[Task (no additional info)](https://propeller-heads.atlassian.net/browse/ENG-4749)

Additional fixes:
- In hashflow/bebop decoders, read auth from env
- Change tokens in test_hashflow_api_polling, since previously used tokens no longer found
- Add mm attribute to HashflowState (may be useful for user when debugging)