### PR TITLE
fix: add missing fields when parsing hashflow quote

### DIFF
--- a/src/rfq/protocols/hashflow/client.rs
+++ b/src/rfq/protocols/hashflow/client.rs
@@ -432,6 +432,13 @@ impl RFQClient for HashflowClient {
                     quote_attributes.insert("pool".to_string(), quote.quote_data.pool);
                     if let Some(external_account) = quote.quote_data.external_account {
                         quote_attributes.insert("external_account".to_string(), external_account);
+                    } else {
+                        quote_attributes.insert(
+                            "external_account".to_string(),
+                            Bytes::from_str(&Address::ZERO.to_string()).map_err(|_| {
+                                RFQError::ParsingError("Failed to parse zero address".to_string())
+                            })?,
+                        );
                     }
                     quote_attributes.insert("trader".to_string(), quote.quote_data.trader);
                     quote_attributes.insert("base_token".to_string(), quote.quote_data.base_token);


### PR DESCRIPTION
The `request_binding_quote` implementation for Hashflow is missing some required fields by the [executor](https://github.com/propeller-heads/tycho-execution/blob/a01229f2ec5f7efdddf863c40c7feec11b7f18ca/foundry/src/executors/HashflowExecutor.sol#L104-L116).