### PR TITLE
feat: change version of github actions/checkout to v5

### DIFF
--- a/.github/workflows/tests-and-lints-template.yaml
+++ b/.github/workflows/tests-and-lints-template.yaml
@@ -48,7 +48,7 @@ jobs:
         run: sudo apt update && sudo apt install -y git
 
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
@@ -92,7 +92,7 @@ jobs:
         run: sudo apt update && sudo apt install -y git
 
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 


### PR DESCRIPTION
[INFRA-158](https://propeller-heads.atlassian.net/browse/INFRA-158) - update ci/cd github **actions/checkout** to v5 due to upgrade ci/cd runner

[INFRA-158]: https://propeller-heads.atlassian.net/browse/INFRA-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ