### PR TITLE
feat: Implement derivative spot_prices function for UniV4 Hooks

### DIFF
--- a/examples/price_printer/ui.rs
+++ b/examples/price_printer/ui.rs
@@ -166,7 +166,10 @@ impl App {
                         }
                         Err(_) => {
                             // Skip pools with spot_price errors
-                            warn!("Skipping pool {comp_id} due to spot_price error", comp_id = comp.id);
+                            warn!(
+                                "Skipping pool {comp_id} due to spot_price error",
+                                comp_id = comp.id
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
The function now handles SimulationError::RecoverableError by calculating the spot price using a swap approximation method (similar to the pattern in src/evm/protocol/vm/state.rs).