### PR TITLE
fix: get_amount_out for usv4 pools w/o hooks

### DIFF
--- a/src/evm/decoder.rs
+++ b/src/evm/decoder.rs
@@ -286,6 +286,7 @@ where
                         .get_vm_storage()
                         .len()
                 );
+
                 let storage_by_address: HashMap<Address, ResponseAccount> = protocol_msg
                     .snapshots
                     .get_vm_storage()

--- a/src/evm/protocol/filters.rs
+++ b/src/evm/protocol/filters.rs
@@ -7,8 +7,6 @@ use tycho_client::feed::synchronizer::ComponentWithState;
 use crate::evm::protocol::vm::utils::json_deserialize_be_bigint_list;
 
 const ZERO_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
-#[allow(dead_code)]
-const ZERO_ADDRESS_ARR: [u8; 20] = [0u8; 20];
 
 // Defines the default Balancer V2 Filter
 pub fn balancer_v2_pool_filter(component: &ComponentWithState) -> bool {

--- a/src/evm/protocol/uniswap_v4/hooks/models.rs
+++ b/src/evm/protocol/uniswap_v4/hooks/models.rs
@@ -70,6 +70,24 @@ impl BalanceDelta {
         BalanceDelta(specified_shifted | unspecified_masked)
     }
 
+    /// Creates a BalanceDelta from swap result's amount_calculated based on swap direction
+    ///
+    /// For exact input swaps:
+    /// - amount_calculated is negative (amount of output token received)
+    /// - We convert it to positive for the appropriate amount field
+    /// - The other amount field is set to zero
+    pub fn from_swap_result(amount_calculated: I256, zero_for_one: bool) -> BalanceDelta {
+        // For exact input swaps, amount_calculated is negative (output amount from pool's
+        // perspective) We negate it to convert to positive amount from user's perspective
+        if zero_for_one {
+            // Swapping token0 for token1: amount_calculated represents change in token1
+            BalanceDelta::new(I128::ZERO, get_lower_i128(-amount_calculated))
+        } else {
+            // Swapping token1 for token0: amount_calculated represents change in token0
+            BalanceDelta::new(get_lower_i128(-amount_calculated), I128::ZERO)
+        }
+    }
+
     pub fn as_i256(&self) -> I256 {
         self.0
     }


### PR DESCRIPTION
New test: `test_get_amount_out_no_hook`

Two bugs fixed:
- We were adding when we should have been subtracting
- BalanceDelta was not being properly initialized

These results were found by comparing `test_get_amount_out_no_hook` results with those of the main branch, and logging intermediate results line-by-line. The findings showed that the result of `compute_swap_step` was the same for both branches, but the calculation differed by sign after calculating `state.amount_calculated`.
The output of `state.amount_remaining` seems to have been properly handled, resulting in 0 for both cases.

The way that BalanceDelta was being handled before gave us `.amount0` and `.amount1` results of `-436478419853848` and `-1` respectively, when we needed to construct it in a way that gave us `0` and `436478419853848` respectively.