### PR TITLE
fix: correctly initialize external account hash

### DIFF
--- a/src/evm/engine_db/tycho_db.rs
+++ b/src/evm/engine_db/tycho_db.rs
@@ -587,7 +587,7 @@ mod tests {
     //     --module map_changes \
     //     --spkg substreams/ethereum-ambient/substreams-ethereum-ambient-v0.3.0.spkg
     /// ```
-    ///
+    /// 
     /// Then run the test with:
     /// ```bash
     /// cargo test --package src --lib -- --ignored --exact --nocapture

--- a/src/evm/engine_db/tycho_db.rs
+++ b/src/evm/engine_db/tycho_db.rs
@@ -6,6 +6,7 @@ use std::{
 use alloy::primitives::{Address, Bytes as AlloyBytes, B256, U256};
 use revm::{
     context::DBErrorMarker,
+    primitives::KECCAK_EMPTY,
     state::{AccountInfo, Bytecode},
     DatabaseRef,
 };
@@ -251,6 +252,12 @@ impl EngineDatabaseInterface for PreCachedDB {
         permanent_storage: Option<HashMap<U256, U256>>,
         _mocked: bool,
     ) {
+        if account.code.is_none() && account.code_hash != KECCAK_EMPTY {
+            warn!("Code is None for account {address} but code hash is not KECCAK_EMPTY");
+        } else if account.code.is_some() && account.code_hash == KECCAK_EMPTY {
+            warn!("Code is Some for account {address} but code hash is KECCAK_EMPTY");
+        }
+
         self.inner
             .write()
             .unwrap()
@@ -580,7 +587,7 @@ mod tests {
     //     --module map_changes \
     //     --spkg substreams/ethereum-ambient/substreams-ethereum-ambient-v0.3.0.spkg
     /// ```
-    /// 
+    ///
     /// Then run the test with:
     /// ```bash
     /// cargo test --package src --lib -- --ignored --exact --nocapture

--- a/src/evm/protocol/uniswap_v4/hooks/hook_handler_creator.rs
+++ b/src/evm/protocol/uniswap_v4/hooks/hook_handler_creator.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::RwLock};
 
 use alloy::primitives::{Address, U256};
 use lazy_static::lazy_static;
-use revm::{primitives::B256, state::AccountInfo};
+use revm::{primitives::KECCAK_EMPTY, state::AccountInfo};
 use tycho_client::feed::BlockHeader;
 use tycho_common::{models::token::Token, simulation::errors::SimulationError, Bytes};
 
@@ -84,8 +84,12 @@ impl HookHandlerCreator for GenericVMHookHandlerCreator {
             )))
         })?;
 
-        let external_account_info =
-            AccountInfo { balance: U256::from(0), nonce: 0u64, code_hash: B256::ZERO, code: None };
+        let external_account_info = AccountInfo {
+            balance: U256::from(0),
+            nonce: 0u64,
+            code_hash: KECCAK_EMPTY,
+            code: None,
+        };
 
         engine
             .state


### PR DESCRIPTION
Account inserted with code set no None must use KECCAK_EMPTY. This commit adds explicit logs when this is not the case.