### PR TITLE
feat: (WIP) Enable adapter overwriting for SDK testing

### DIFF
--- a/src/evm/protocol/vm/adapter_contract.rs
+++ b/src/evm/protocol/vm/adapter_contract.rs
@@ -8,6 +8,7 @@ use alloy::{
     sol_types::SolValue,
 };
 use revm::DatabaseRef;
+use tracing::info;
 use tycho_common::simulation::errors::SimulationError;
 
 use super::{
@@ -150,9 +151,13 @@ where
         let args = (string_to_bytes32(pair_id)?, sell_token, buy_token);
         let selector = "getCapabilities(bytes32,address,address)";
 
-        let res = self
-            .call(selector, args, 1, None, None, None, U256::from(0u64), None)?
-            .return_value;
+        let call_output = self
+            .call(selector, args, 1, None, None, None, U256::from(0u64), None)?;
+        // TODO why is it None :( Is the bytecode wrong?
+        // My result:
+        // TychoSimulationResponse { return_value: [], simulation_result: SimulationResult { result: 0x, state_updates: {0x00000000000000746573745f70726f746f636f6c: StateUpdate { storage: None, balance: Some(57896044618658097711785492504343953926634992332820282019728792003956564819967) }, 0xf847a638e44186f3287ee9f8caf73ff4d4b80784: StateUpdate { storage: None, balance: Some(57896044618658097711785492504343953926634992332820282019728792003956564819967) }, 0x0000000000000000000000000000000000000000: StateUpdate { storage: None, balance: Some(0) }}, gas_used: 24010, transient_storage: {} } }
+        info!("call_output: {call_output:?}");
+        let res = call_output.return_value;
         let decoded: CapabilitiesReturn = CapabilitiesReturn::abi_decode(&res).map_err(|e| {
             SimulationError::FatalError(format!(
                 "Adapter get_capabilities call failed: Failed to decode return value: {e:?}"

--- a/src/evm/protocol/vm/constants.rs
+++ b/src/evm/protocol/vm/constants.rs
@@ -17,11 +17,14 @@ pub const BALANCER_V3: &[u8] = include_bytes!("assets/BalancerV3SwapAdapter.evm.
 pub const CURVE: &[u8] = include_bytes!("assets/CurveSwapAdapter.evm.runtime");
 pub const MAVERICK_V2: &[u8] = include_bytes!("assets/MaverickV2SwapAdapter.evm.runtime");
 pub fn get_adapter_file(protocol: &str) -> Result<&'static [u8], SimulationError> {
+    let empty: &[u8] = &[];
     match protocol {
         "balancer_v2" => Ok(BALANCER_V2),
         "balancer_v3" => Ok(BALANCER_V3),
         "curve" => Ok(CURVE),
         "maverick_v2" => Ok(MAVERICK_V2),
+        // Used only for integration tests
+        "test_protocol" => Ok(empty),
         _ => Err(SimulationError::FatalError(format!("Adapter for protocol {protocol} not found"))),
     }
 }

--- a/src/evm/protocol/vm/tycho_decoder.rs
+++ b/src/evm/protocol/vm/tycho_decoder.rs
@@ -139,6 +139,10 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for EVMPoolState<PreCache
                 .stateless_contracts(stateless_contracts)
                 .manual_updates(manual_updates);
 
+        if protocol_name == "test_protocol" {
+            pool_state_builder = pool_state_builder.test()
+        }
+
         if let Some(balance_owner) = balance_owner {
             pool_state_builder = pool_state_builder.balance_owner(balance_owner)
         };
@@ -148,7 +152,9 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for EVMPoolState<PreCache
             .await
             .map_err(InvalidSnapshotError::VMError)?;
 
-        pool_state.set_spot_prices(all_tokens)?;
+        if protocol_name != "test_protocol" {
+            pool_state.set_spot_prices(all_tokens)?;
+        }
 
         Ok(pool_state)
     }


### PR DESCRIPTION
- The biggest challenge is that the adapter must not be called before the pool state is returned (i.e. during decoding) because we don't have access to the adapter.
- In order to avoid changing interfaces, instead of passing the adapter bytecode in some convoluted way to the decoding, I just set it in the state after I already decode, and call the necessary methods again later (capabilities, spot_price). This is hacky but I don't know of a better way to do it.

The call for getting capabilities fails and I'm not sure why yet.