### PR TITLE
feat(Testing SDK): Pass adapter contract to decoder

### DIFF
--- a/src/evm/protocol/ekubo/test_cases.rs
+++ b/src/evm/protocol/ekubo/test_cases.rs
@@ -465,26 +465,26 @@ pub fn twamm() -> TestCase {
             ("token1_sale_rate".to_string(), 0_u128.to_be_bytes().into()),
             ("last_execution_time".to_string(), 0_u64.to_be_bytes().into()),
             (
-                format!("orders/token0/{}", FIRST_ORDER_START_TIME),
+                format!("orders/token0/{FIRST_ORDER_START_TIME}"),
                 (TOKEN0_SALE_RATE as i128)
                     .to_be_bytes()
                     .into(),
             ),
             (
-                format!("orders/token1/{}", FIRST_ORDER_START_TIME),
+                format!("orders/token1/{FIRST_ORDER_START_TIME}"),
                 (TOKEN1_SALE_RATE as i128)
                     .to_be_bytes()
                     .into(),
             ),
             (
-                format!("orders/token0/{}", FIRST_ORDER_END_TIME),
+                format!("orders/token0/{FIRST_ORDER_END_TIME}"),
                 (TOKEN0_SALE_RATE as i128)
                     .neg()
                     .to_be_bytes()
                     .into(),
             ),
             (
-                format!("orders/token1/{}", FIRST_ORDER_END_TIME),
+                format!("orders/token1/{FIRST_ORDER_END_TIME}"),
                 (TOKEN1_SALE_RATE as i128)
                     .neg()
                     .to_be_bytes()

--- a/src/evm/protocol/ekubo/tycho_decoder.rs
+++ b/src/evm/protocol/ekubo/tycho_decoder.rs
@@ -57,6 +57,7 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for EkuboState {
         _block: BlockHeader,
         _account_balances: &HashMap<Bytes, HashMap<Bytes, Bytes>>,
         _all_tokens: &HashMap<Bytes, Token>,
+        _adapter_path: Option<&str>,
     ) -> Result<Self, Self::Error> {
         let static_attrs = snapshot.component.static_attributes;
         let state_attrs = snapshot.state.attributes;
@@ -213,6 +214,7 @@ mod tests {
             BlockHeader::default(),
             &HashMap::new(),
             &HashMap::new(),
+            None,
         )
         .await
         .expect("reconstructing state");
@@ -248,6 +250,7 @@ mod tests {
                 BlockHeader::default(),
                 &HashMap::default(),
                 &HashMap::default(),
+                None,
             )
             .await;
 

--- a/src/evm/protocol/pancakeswap_v2/tycho_decoder.rs
+++ b/src/evm/protocol/pancakeswap_v2/tycho_decoder.rs
@@ -20,6 +20,7 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for PancakeswapV2State {
         _block: BlockHeader,
         _account_balances: &HashMap<Bytes, HashMap<Bytes, Bytes>>,
         _all_tokens: &HashMap<Bytes, Token>,
+        _adapter_path: Option<&str>,
     ) -> Result<Self, Self::Error> {
         let (reserve0, reserve1) = cpmm_try_from_with_header(snapshot)?;
         Ok(Self::new(reserve0, reserve1))
@@ -69,6 +70,7 @@ mod tests {
             header(),
             &HashMap::new(),
             &HashMap::new(),
+            None,
         )
         .await;
 
@@ -103,6 +105,7 @@ mod tests {
             header(),
             &HashMap::new(),
             &HashMap::new(),
+            None,
         )
         .await;
 

--- a/src/evm/protocol/uniswap_v2/tycho_decoder.rs
+++ b/src/evm/protocol/uniswap_v2/tycho_decoder.rs
@@ -18,6 +18,7 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for UniswapV2State {
         _block: BlockHeader,
         _account_balances: &HashMap<Bytes, HashMap<Bytes, Bytes>>,
         _all_tokens: &HashMap<Bytes, Token>,
+        _adapter_path: Option<&str>,
     ) -> Result<Self, Self::Error> {
         let (reserve0, reserve1) = cpmm_try_from_with_header(snapshot)?;
         Ok(Self::new(reserve0, reserve1))
@@ -67,6 +68,7 @@ mod tests {
             header(),
             &HashMap::new(),
             &HashMap::new(),
+            None,
         )
         .await;
 
@@ -101,6 +103,7 @@ mod tests {
             header(),
             &HashMap::new(),
             &HashMap::new(),
+            None,
         )
         .await;
 

--- a/src/evm/protocol/uniswap_v3/state.rs
+++ b/src/evm/protocol/uniswap_v3/state.rs
@@ -772,6 +772,7 @@ mod tests {
             Default::default(),
             &Default::default(),
             &Default::default(),
+            None,
         )
         .await
         .unwrap();
@@ -836,6 +837,7 @@ mod tests_forks {
             Default::default(),
             &Default::default(),
             &Default::default(),
+            None,
         )
         .await
         .unwrap();

--- a/src/evm/protocol/uniswap_v3/tycho_decoder.rs
+++ b/src/evm/protocol/uniswap_v3/tycho_decoder.rs
@@ -20,6 +20,7 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for UniswapV3State {
         _block: BlockHeader,
         _account_balances: &HashMap<Bytes, HashMap<Bytes, Bytes>>,
         _all_tokens: &HashMap<Bytes, Token>,
+        _adapter_path: Option<&str>,
     ) -> Result<Self, Self::Error> {
         let liq = snapshot
             .state
@@ -194,6 +195,7 @@ mod tests {
             header(),
             &HashMap::new(),
             &HashMap::new(),
+            None,
         )
         .await;
 
@@ -251,6 +253,7 @@ mod tests {
             header(),
             &HashMap::new(),
             &HashMap::new(),
+            None,
         )
         .await;
 
@@ -285,6 +288,7 @@ mod tests {
             header(),
             &HashMap::new(),
             &HashMap::new(),
+            None,
         )
         .await;
 

--- a/src/evm/protocol/uniswap_v4/state.rs
+++ b/src/evm/protocol/uniswap_v4/state.rs
@@ -958,6 +958,7 @@ mod tests {
             block,
             &Default::default(),
             &Default::default(),
+            None,
         )
         .await
         .unwrap();
@@ -1039,6 +1040,7 @@ mod tests {
             block,
             &Default::default(),
             &Default::default(),
+            None,
         )
         .await
         .unwrap();

--- a/src/evm/protocol/uniswap_v4/tycho_decoder.rs
+++ b/src/evm/protocol/uniswap_v4/tycho_decoder.rs
@@ -26,6 +26,7 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for UniswapV4State {
         block: BlockHeader,
         account_balances: &HashMap<Bytes, HashMap<Bytes, Bytes>>,
         all_tokens: &HashMap<Bytes, Token>,
+        _adapter_path: Option<&str>,
     ) -> Result<Self, Self::Error> {
         let liq = snapshot
             .state
@@ -253,6 +254,7 @@ mod tests {
             header(),
             &HashMap::new(),
             &HashMap::new(),
+            None,
         )
         .await
         .unwrap();
@@ -326,6 +328,7 @@ mod tests {
             header(),
             &HashMap::new(),
             &HashMap::new(),
+            None,
         )
         .await;
 

--- a/src/evm/protocol/vm/tycho_decoder.rs
+++ b/src/evm/protocol/vm/tycho_decoder.rs
@@ -6,7 +6,7 @@ use std::{
 use alloy::primitives::{Address, U256};
 use revm::state::Bytecode;
 use tycho_client::feed::{synchronizer::ComponentWithState, BlockHeader};
-use tycho_common::{models::token::Token, Bytes};
+use tycho_common::{models::token::Token, simulation::errors::SimulationError, Bytes};
 
 use super::{state::EVMPoolState, state_builder::EVMPoolStateBuilder};
 use crate::{
@@ -30,6 +30,7 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for EVMPoolState<PreCache
         block: BlockHeader,
         account_balances: &HashMap<Bytes, HashMap<Bytes, Bytes>>,
         all_tokens: &HashMap<Bytes, Token>,
+        adapter_path: Option<&str>,
     ) -> Result<Self, Self::Error> {
         let id = snapshot.component.id.clone();
         let tokens = snapshot.component.tokens.clone();
@@ -119,7 +120,17 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for EVMPoolState<PreCache
                     .protocol_system
                     .as_str()
             });
-        let adapter_bytecode = Bytecode::new_raw(get_adapter_file(protocol_name)?.into());
+        let adapter_bytecode;
+        if let Some(adapter_bytecode_path) = adapter_path {
+            let bytecode_bytes = std::fs::read(adapter_bytecode_path).map_err(|e| {
+                SimulationError::FatalError(format!(
+                    "Failed to read adapter bytecode from {adapter_bytecode_path}: {e}"
+                ))
+            })?;
+            adapter_bytecode = Bytecode::new_raw(bytecode_bytes.into());
+        } else {
+            adapter_bytecode = Bytecode::new_raw(get_adapter_file(protocol_name)?.into());
+        }
         let adapter_contract_address = Address::from_str(&format!(
             "{hex_protocol_name:0>40}",
             hex_protocol_name = hex::encode(protocol_name)
@@ -308,10 +319,15 @@ mod tests {
             ]),
         )]);
 
-        let res =
-            EVMPoolState::try_from_with_header(snapshot, header(), &account_balances, &tokens)
-                .await
-                .unwrap();
+        let res = EVMPoolState::try_from_with_header(
+            snapshot,
+            header(),
+            &account_balances,
+            &tokens,
+            None,
+        )
+        .await
+        .unwrap();
 
         let res_pool = res;
 

--- a/src/evm/stream.rs
+++ b/src/evm/stream.rs
@@ -81,7 +81,8 @@ impl ProtocolStreamBuilder {
         self.stream_builder = self
             .stream_builder
             .exchange(name, filter);
-        self.decoder.register_decoder::<T>(name);
+        self.decoder
+            .register_decoder::<T>(name, None);
         if let Some(predicate) = filter_fn {
             self.decoder
                 .register_filter(name, predicate);

--- a/src/protocol/models.rs
+++ b/src/protocol/models.rs
@@ -135,6 +135,7 @@ where
         block: H,
         account_balances: &HashMap<Bytes, HashMap<Bytes, Bytes>>,
         all_tokens: &HashMap<Bytes, Token>,
+        adapter_path: Option<&str>,
     ) -> impl Future<Output = Result<Self, Self::Error>> + Send + Sync
     where
         Self: Sized;

--- a/src/rfq/protocols/bebop/models.rs
+++ b/src/rfq/protocols/bebop/models.rs
@@ -505,7 +505,7 @@ mod tests {
             }
             let params = params();
             let err = quote.validate(&params).unwrap_err();
-            assert!(format!("{:?}", err).contains("Base token mismatch"));
+            assert!(format!("{err:?}").contains("Base token mismatch"));
         }
 
         #[test]
@@ -516,7 +516,7 @@ mod tests {
             }
             let params = params();
             let err = quote.validate(&params).unwrap_err();
-            assert!(format!("{:?}", err).contains("Quote token mismatch"));
+            assert!(format!("{err:?}").contains("Quote token mismatch"));
         }
 
         #[test]
@@ -527,7 +527,7 @@ mod tests {
             }
             let params = params();
             let err = quote.validate(&params).unwrap_err();
-            assert!(format!("{:?}", err).contains("Taker address mismatch"));
+            assert!(format!("{err:?}").contains("Taker address mismatch"));
         }
 
         #[test]
@@ -538,7 +538,7 @@ mod tests {
             }
             let params = params();
             let err = quote.validate(&params).unwrap_err();
-            assert!(format!("{:?}", err).contains("Receiver address mismatch"));
+            assert!(format!("{err:?}").contains("Receiver address mismatch"));
         }
 
         #[test]
@@ -549,7 +549,7 @@ mod tests {
             }
             let params = params();
             let err = quote.validate(&params).unwrap_err();
-            assert!(format!("{:?}", err).contains("Base token amount mismatch"));
+            assert!(format!("{err:?}").contains("Base token amount mismatch"));
         }
 
         #[test]
@@ -567,7 +567,7 @@ mod tests {
             }
             let params = params();
             let err = quote.validate(&params).unwrap_err();
-            assert!(format!("{:?}", err).contains("Taker address mismatch"));
+            assert!(format!("{err:?}").contains("Taker address mismatch"));
         }
 
         #[test]
@@ -578,7 +578,7 @@ mod tests {
             }
             let params = params();
             let err = quote.validate(&params).unwrap_err();
-            assert!(format!("{:?}", err).contains("Receiver address mismatch"));
+            assert!(format!("{err:?}").contains("Receiver address mismatch"));
         }
     }
 }

--- a/src/rfq/protocols/bebop/tycho_decoder.rs
+++ b/src/rfq/protocols/bebop/tycho_decoder.rs
@@ -20,6 +20,7 @@ impl TryFromWithBlock<ComponentWithState, TimestampHeader> for BebopState {
         timestamp_header: TimestampHeader,
         _account_balances: &HashMap<Bytes, HashMap<Bytes, Bytes>>,
         all_tokens: &HashMap<Bytes, Token>,
+        _adapter_path: Option<&str>,
     ) -> Result<Self, Self::Error> {
         let state_attrs = snapshot.state.attributes;
 
@@ -192,6 +193,7 @@ mod tests {
             TimestampHeader { timestamp: 1703097600u64 },
             &HashMap::new(),
             &tokens,
+            None,
         )
         .await
         .expect("create state from snapshot");
@@ -218,6 +220,7 @@ mod tests {
             TimestampHeader::default(),
             &HashMap::new(),
             &tokens,
+            None,
         )
         .await;
         assert!(result.is_err());
@@ -236,6 +239,7 @@ mod tests {
             TimestampHeader::default(),
             &HashMap::new(),
             &tokens,
+            None,
         )
         .await
         .expect("create state from snapshot");
@@ -262,6 +266,7 @@ mod tests {
             TimestampHeader::default(),
             &HashMap::new(),
             &tokens,
+            None,
         )
         .await;
         assert!(result.is_err());

--- a/src/rfq/protocols/hashflow/models.rs
+++ b/src/rfq/protocols/hashflow/models.rs
@@ -394,7 +394,7 @@ mod tests {
                 hex_to_bytes("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
             let params = params();
             let err = quote.validate(&params).unwrap_err();
-            assert!(format!("{:?}", err).contains("Base token mismatch"));
+            assert!(format!("{err:?}").contains("Base token mismatch"));
         }
 
         #[test]
@@ -404,7 +404,7 @@ mod tests {
                 hex_to_bytes("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
             let params = params();
             let err = quote.validate(&params).unwrap_err();
-            assert!(format!("{:?}", err).contains("Quote token mismatch"));
+            assert!(format!("{err:?}").contains("Quote token mismatch"));
         }
 
         #[test]
@@ -413,7 +413,7 @@ mod tests {
             quote.quote_data.trader = hex_to_bytes("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
             let params = params();
             let err = quote.validate(&params).unwrap_err();
-            assert!(format!("{:?}", err).contains("Trader address mismatch"));
+            assert!(format!("{err:?}").contains("Trader address mismatch"));
         }
 
         #[test]
@@ -422,7 +422,7 @@ mod tests {
             quote.quote_data.base_token_amount = "9999".to_string();
             let params = params();
             let err = quote.validate(&params).unwrap_err();
-            assert!(format!("{:?}", err).contains("Base token amount mismatch"));
+            assert!(format!("{err:?}").contains("Base token amount mismatch"));
         }
     }
 }

--- a/src/rfq/protocols/hashflow/tycho_decoder.rs
+++ b/src/rfq/protocols/hashflow/tycho_decoder.rs
@@ -23,6 +23,7 @@ impl TryFromWithBlock<ComponentWithState, TimestampHeader> for HashflowState {
         _timestamp_header: TimestampHeader,
         _account_balances: &HashMap<Bytes, HashMap<Bytes, Bytes>>,
         all_tokens: &HashMap<Bytes, Token>,
+        _adapter_path: Option<&str>,
     ) -> Result<Self, Self::Error> {
         let state_attrs = snapshot.state.attributes;
 
@@ -227,6 +228,7 @@ mod tests {
             TimestampHeader { timestamp: 1703097600u64 },
             &HashMap::new(),
             &tokens,
+            None,
         )
         .await
         .expect("create state from snapshot");
@@ -259,6 +261,7 @@ mod tests {
             TimestampHeader::default(),
             &HashMap::new(),
             &tokens,
+            None,
         )
         .await
         .expect("create state with missing levels should default to empty levels");
@@ -283,6 +286,7 @@ mod tests {
             TimestampHeader::default(),
             &HashMap::new(),
             &tokens,
+            None,
         )
         .await;
 
@@ -321,6 +325,7 @@ mod tests {
             TimestampHeader::default(),
             &HashMap::new(),
             &tokens,
+            None,
         )
         .await;
 
@@ -349,6 +354,7 @@ mod tests {
             TimestampHeader::default(),
             &HashMap::new(),
             &tokens,
+            None,
         )
         .await;
 
@@ -369,6 +375,7 @@ mod tests {
             TimestampHeader::default(),
             &HashMap::new(),
             &tokens,
+            None,
         )
         .await;
 

--- a/src/rfq/stream.rs
+++ b/src/rfq/stream.rs
@@ -50,7 +50,8 @@ impl RFQStreamBuilder {
             + 'static,
     {
         self.clients.push(provider);
-        self.decoder.register_decoder::<T>(name);
+        self.decoder
+            .register_decoder::<T>(name, None);
         self
     }
 
@@ -180,6 +181,7 @@ mod tests {
             _header: TimestampHeader,
             _account_balances: &HashMap<Bytes, HashMap<Bytes, Bytes>>,
             _all_tokens: &HashMap<Bytes, Token>,
+            _adapter_path: Option<&str>,
         ) -> Result<Self, Self::Error> {
             Ok(DummyProtocol)
         }


### PR DESCRIPTION
We need to be able to use the adapter passed by the testing SDK.

This was the most elegant solution we could come up with at the moment for having the proper adapter in the builder.

Notes:
- The default adapter bytecode in tycho-simulation is still loaded at compile time.
- If the adapter bytecode is passed to the decoder, it will be loaded dynamically at runtime and used instead the already-loaded bytecodes in tycho-simulation.

Reasons for not using other methods:
- The adapter bytecode is used in the builder to get capabilities and thus spot prices before returning the state, so just overwriting the adapter in the state is way too cumbersome. We went with this solution since it was the lesser evil, even though we know it leaks VM-specific info to non-vm protocols (which was already being done anyway with the balances).
- Reading from a fixed filepath was not an option because this could cause race conditions if we tried to parallelize.