### PR TITLE
feat: Propagate db update errors

### DIFF
--- a/src/evm/engine_db/mod.rs
+++ b/src/evm/engine_db/mod.rs
@@ -7,7 +7,10 @@ use tycho_client::feed::BlockHeader;
 use tycho_common::simulation::errors::SimulationError;
 
 use crate::evm::{
-    engine_db::{engine_db_interface::EngineDatabaseInterface, tycho_db::PreCachedDB},
+    engine_db::{
+        engine_db_interface::EngineDatabaseInterface,
+        tycho_db::{PreCachedDB, PreCachedDBError},
+    },
     simulation::SimulationEngine,
     tycho_models::{AccountUpdate, ChangeType, ResponseAccount},
 };
@@ -70,7 +73,7 @@ pub async fn update_engine(
     block: Option<BlockHeader>,
     vm_storage: Option<HashMap<Address, ResponseAccount>>,
     account_updates: HashMap<Address, AccountUpdate>,
-) -> Vec<AccountUpdate> {
+) -> Result<Vec<AccountUpdate>, PreCachedDBError> {
     if let Some(block) = block {
         let mut vm_updates: Vec<AccountUpdate> = Vec::new();
 
@@ -93,11 +96,11 @@ pub async fn update_engine(
         }
 
         if !vm_updates.is_empty() {
-            db.update(vm_updates.clone(), Some(block));
+            db.update(vm_updates.clone(), Some(block))?;
         }
 
-        vm_updates
+        Ok(vm_updates)
     } else {
-        vec![]
+        Ok(vec![])
     }
 }

--- a/src/evm/engine_db/tycho_db.rs
+++ b/src/evm/engine_db/tycho_db.rs
@@ -36,6 +36,8 @@ pub enum TychoClientError {
 pub enum PreCachedDBError {
     #[error("Account {0} not found")]
     MissingAccount(Address),
+    #[error("Bad account update: {0} - {1:?}")]
+    BadUpdate(String, Box<AccountUpdate>),
     #[error("Block needs to be set")]
     BlockNotSet(),
     #[error("Tycho Client error: {0}")]
@@ -76,10 +78,17 @@ impl PreCachedDB {
     }
 
     #[instrument(skip_all)]
-    pub fn update(&self, account_updates: Vec<AccountUpdate>, block: Option<BlockHeader>) {
+    pub fn update(
+        &self,
+        account_updates: Vec<AccountUpdate>,
+        block: Option<BlockHeader>,
+    ) -> Result<(), PreCachedDBError> {
         // Hold the write lock for the duration of the function so that no other thread can
         // write to the storage.
-        let mut write_guard = self.inner.write().unwrap();
+        let mut write_guard = self
+            .inner
+            .write()
+            .expect("Fatal tycho state db lock poisoned");
 
         write_guard.block = block;
 
@@ -108,10 +117,13 @@ impl PreCachedDB {
 
                     // We expect the code to be present.
                     let code = Bytecode::new_raw(AlloyBytes::from(
-                        update.code.clone().unwrap_or_else(|| {
+                        update.code.clone().ok_or_else(|| {
                             error!(%update.address, "MissingCode");
-                            Vec::new()
-                        }),
+                            PreCachedDBError::BadUpdate(
+                                "MissingCode".into(),
+                                Box::new(update.clone()),
+                            )
+                        })?,
                     ));
                     // If the balance is not present, we set it to zero.
                     let balance = update.balance.unwrap_or(U256::ZERO);
@@ -130,6 +142,7 @@ impl PreCachedDB {
                 }
             }
         }
+        Ok(())
     }
 
     /// Retrieves the storage value at the specified index for the given account, if it exists.
@@ -552,7 +565,9 @@ mod tests {
             ..Default::default()
         };
 
-        mock_db.update(vec![account_update], Some(new_block));
+        mock_db
+            .update(vec![account_update], Some(new_block))
+            .unwrap();
 
         let account_info = mock_db
             .basic_ref(Address::from_str("0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D").unwrap())

--- a/src/evm/protocol/vm/state.rs
+++ b/src/evm/protocol/vm/state.rs
@@ -790,7 +790,8 @@ mod tests {
                 false,
             );
         }
-        db.update(accounts, Some(block));
+        db.update(accounts, Some(block))
+            .unwrap();
 
         let tokens = vec![dai().address, bal().address];
         for token in &tokens {

--- a/src/evm/protocol/vm/tycho_decoder.rs
+++ b/src/evm/protocol/vm/tycho_decoder.rs
@@ -311,7 +311,8 @@ mod tests {
                 false,
             );
         }
-        db.update(accounts, Some(block));
+        db.update(accounts, Some(block))
+            .unwrap();
         let account_balances = HashMap::from([(
             Bytes::from("0xBA12222222228d8Ba445958a75a0704d566BF2C8"),
             HashMap::from([

--- a/src/rfq/stream.rs
+++ b/src/rfq/stream.rs
@@ -68,7 +68,7 @@ impl RFQStreamBuilder {
                 Ok((provider, msg)) => {
                     let update = self
                         .decoder
-                        .decode(FeedMessage {
+                        .decode(&FeedMessage {
                             state_msgs: HashMap::from([(provider.clone(), msg)]),
                             sync_states: HashMap::new(),
                         })

--- a/tycho_simulation_py/src/structs_py.rs
+++ b/tycho_simulation_py/src/structs_py.rs
@@ -537,6 +537,7 @@ impl TychoDB {
 
         self_
             .inner
-            .update(account_updates, block);
+            .update(account_updates, block)
+            .unwrap();
     }
 }


### PR DESCRIPTION
Propagate errors from PreCacheDB::update all the way up to decoding and log the full message that failed to decode. To see full messages that failed decoding set `RUST_LOG=info,tycho_simulation::evm::stream=debug`.

Additionally, this adds a temporary patch to treat AccountDeltas marked as creations without code as updates.