### PR TITLE
feat: Add vm_trace to DecoderContext

### DIFF
--- a/src/evm/protocol/vm/tycho_decoder.rs
+++ b/src/evm/protocol/vm/tycho_decoder.rs
@@ -143,7 +143,10 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for EVMPoolState<PreCache
                 "Error converting protocol name to address".to_string(),
             )
         })?;
-
+        let mut vm_traces = false;
+        if let Some(trace) = &decoder_context.vm_traces {
+            vm_traces = *trace;
+        }
         let mut pool_state_builder =
             EVMPoolStateBuilder::new(id.clone(), tokens.clone(), block, adapter_contract_address)
                 .balances(component_balances)
@@ -151,7 +154,8 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for EVMPoolState<PreCache
                 .adapter_contract_bytecode(adapter_bytecode)
                 .involved_contracts(involved_contracts)
                 .stateless_contracts(stateless_contracts)
-                .manual_updates(manual_updates);
+                .manual_updates(manual_updates)
+                .trace(vm_traces);
 
         if let Some(balance_owner) = balance_owner {
             pool_state_builder = pool_state_builder.balance_owner(balance_owner)

--- a/src/protocol/models.rs
+++ b/src/protocol/models.rs
@@ -41,15 +41,21 @@ use tycho_common::{
 #[derive(Debug, Clone)]
 pub struct DecoderContext {
     pub adapter_path: Option<String>,
+    pub vm_traces: Option<bool>,
 }
 
 impl DecoderContext {
     pub fn new() -> Self {
-        Self { adapter_path: None }
+        Self { adapter_path: None, vm_traces: None }
     }
 
     pub fn vm_adapter_path<S: Into<String>>(mut self, path: S) -> Self {
         self.adapter_path = Some(path.into());
+        self
+    }
+
+    pub fn vm_traces(mut self, trace: bool) -> Self {
+        self.vm_traces = Some(trace);
         self
     }
 }


### PR DESCRIPTION
This enables us to control from the outside if vm traces are displayed or not during simulations
