### PR TITLE
fix: Solve issue with low balance tokens in pool manager 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,6 +1725,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.16",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4487,6 +4501,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -8411,11 +8434,13 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.83.1"
-source = "git+https://github.com/propeller-heads/tycho-indexer?rev=c84e665502543935e276c032fdd61b9e11b20575#c84e665502543935e276c032fdd61b9e11b20575"
+version = "0.88.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d30ad4ffa3cefb328f3e0ca3870c06ddfaecdd74686844cced08d3acbdc9ff81"
 dependencies = [
  "anyhow",
  "async-trait",
+ "backoff",
  "chrono",
  "clap",
  "futures 0.3.31",
@@ -8426,44 +8451,21 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "time",
  "tokio",
  "tokio-tungstenite 0.20.1",
  "tracing",
  "tracing-appender",
  "tracing-subscriber 0.3.19",
- "tycho-common 0.83.1",
+ "tycho-common",
  "uuid 1.17.0",
 ]
 
 [[package]]
 name = "tycho-common"
-version = "0.83.1"
-source = "git+https://github.com/propeller-heads/tycho-indexer?rev=c84e665502543935e276c032fdd61b9e11b20575#c84e665502543935e276c032fdd61b9e11b20575"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "chrono",
- "hex",
- "num-bigint",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "strum 0.25.0",
- "strum_macros 0.25.3",
- "thiserror 1.0.69",
- "tiny-keccak",
- "tracing",
- "typetag",
- "utoipa",
- "uuid 1.17.0",
-]
-
-[[package]]
-name = "tycho-common"
-version = "0.83.4"
+version = "0.88.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ecbbf6f701a01569e351d19ee3a3e36418e8d1be539fd6ed925137eb84a2b2"
+checksum = "da3d11794b59200b15d07afdb29323b99db66e757966aa0b71af885a36bbf178"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8486,9 +8488,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.124.0"
+version = "0.125.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da3bca6f82da18f6e59a995ba1dfe416a070a0e0a1dc58ef5bc5a9f288de783"
+checksum = "90d1b18ddf0f5018af1294956cefc00a7b3893f6135df12c22776728af1402a0"
 dependencies = [
  "alloy",
  "chrono",
@@ -8503,7 +8505,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "tycho-common 0.83.4",
+ "tycho-common",
 ]
 
 [[package]]
@@ -8555,7 +8557,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber 0.3.19",
  "tycho-client",
- "tycho-common 0.83.1",
+ "tycho-common",
  "tycho-execution",
  "unicode-width 0.1.14",
  "uuid 1.17.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8411,9 +8411,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.83.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da113f5301ba1fb8e4441df405afa1e7b728a83017681b94851c5bc36d758dc"
+version = "0.83.1"
+source = "git+https://github.com/propeller-heads/tycho-indexer?rev=c84e665502543935e276c032fdd61b9e11b20575#c84e665502543935e276c032fdd61b9e11b20575"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8432,7 +8431,31 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber 0.3.19",
- "tycho-common",
+ "tycho-common 0.83.1",
+ "uuid 1.17.0",
+]
+
+[[package]]
+name = "tycho-common"
+version = "0.83.1"
+source = "git+https://github.com/propeller-heads/tycho-indexer?rev=c84e665502543935e276c032fdd61b9e11b20575#c84e665502543935e276c032fdd61b9e11b20575"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "hex",
+ "num-bigint",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
+ "thiserror 1.0.69",
+ "tiny-keccak",
+ "tracing",
+ "typetag",
+ "utoipa",
  "uuid 1.17.0",
 ]
 
@@ -8480,7 +8503,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "tycho-common",
+ "tycho-common 0.83.4",
 ]
 
 [[package]]
@@ -8532,7 +8555,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber 0.3.19",
  "tycho-client",
- "tycho-common",
+ "tycho-common 0.83.1",
  "tycho-execution",
  "unicode-width 0.1.14",
  "uuid 1.17.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,8 @@ mini-moka = "0.10"
 lazy_static = "1.4.0"
 
 # Tycho dependencies
-tycho-client = { git = "https://github.com/propeller-heads/tycho-indexer", rev = "c84e665502543935e276c032fdd61b9e11b20575" }
-tycho-common = { git = "https://github.com/propeller-heads/tycho-indexer", rev = "c84e665502543935e276c032fdd61b9e11b20575" }
+tycho-client = "0.88.0"
+tycho-common = "0.88.0"
 
 # EVM dependencies
 foundry-config = { git = "https://github.com/foundry-rs/foundry", rev = "5a552bb0de7126fa35170fd84532bbd3d40cd348", optional = true }
@@ -75,7 +75,7 @@ async-stream = { version = "0.3.6", optional = true }
 http = { version = "1.0", optional = true }
 prost = { version = "0.13", optional = true }
 # tycho execution for quickstart
-tycho-execution = "0.124.0"
+tycho-execution = "0.125.0"
 
 [dev-dependencies]
 tokio-test = "0.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,8 @@ mini-moka = "0.10"
 lazy_static = "1.4.0"
 
 # Tycho dependencies
-tycho-common = "0.83.3"
-tycho-client = "0.83.3"
+tycho-client = { git = "https://github.com/propeller-heads/tycho-indexer", rev = "c84e665502543935e276c032fdd61b9e11b20575" }
+tycho-common = { git = "https://github.com/propeller-heads/tycho-indexer", rev = "c84e665502543935e276c032fdd61b9e11b20575" }
 
 # EVM dependencies
 foundry-config = { git = "https://github.com/foundry-rs/foundry", rev = "5a552bb0de7126fa35170fd84532bbd3d40cd348", optional = true }

--- a/src/evm/decoder.rs
+++ b/src/evm/decoder.rs
@@ -1214,7 +1214,7 @@ mod tests {
 
         decoder.set_tokens(tokens.clone()).await;
 
-        let msg = load_test_msg("hook_state");
+        let msg = load_test_msg("euler_hook_snapshot");
         let res = decoder
             .decode(&msg)
             .await
@@ -1227,11 +1227,11 @@ mod tests {
         let amount_out = pool_state
             .get_amount_out(
                 BigUint::from_str("1000000000000000000").unwrap(),
-                &tokens.get(&teth).unwrap(),
-                &tokens.get(&weth).unwrap(),
+                tokens.get(&teth).unwrap(),
+                tokens.get(&weth).unwrap(),
             )
             .expect("Get amount out failed");
 
-        println!("amount: {:?}", amount_out);
+        assert_eq!(amount_out.amount, BigUint::from_str("1216190190361759119").unwrap());
     }
 }

--- a/src/evm/protocol/uniswap_v4/hooks/generic_vm_hook_handler.rs
+++ b/src/evm/protocol/uniswap_v4/hooks/generic_vm_hook_handler.rs
@@ -115,12 +115,13 @@ where
             params.context.currency_1
         };
         let mut token_overwrites = TokenProxyOverwriteFactory::new(token_in, None);
+        // Overwrite pool manager's balance of token in. This is relevant when the pool manager does
+        // not have a lot of these tokens and the hook assumes that the token in is transferred
+        // before before_swap
         token_overwrites.set_balance(U256::MAX, self.pool_manager);
-        // token_overwrites.set_allowance(
-        //     U256::MAX,
-        //     Address::from_str("0xA28C23a459fF8773EB4dBe0e7250d93F79F1Fe2B").unwrap(),
-        //     self.address,
-        // );
+        // This is only to set the custom allowance flag to true, so we can fall in this condition
+        // https://github.com/propeller-heads/tycho-simulation/blob/23c3b1fbacdf4cccec62b633c109e668c6d5f12a/token-proxy/src/TokenProxy.sol#L342
+        token_overwrites.set_allowance(U256::MAX, Address::ZERO, self.address);
         let mut final_overwrites = token_overwrites.get_overwrites();
         if let Some(input_overwrites) = overwrites {
             final_overwrites.extend(input_overwrites)

--- a/src/evm/protocol/uniswap_v4/hooks/hook_handler_creator.rs
+++ b/src/evm/protocol/uniswap_v4/hooks/hook_handler_creator.rs
@@ -47,16 +47,7 @@ impl<'a> HookCreationParams<'a> {
         balances: &'a HashMap<Bytes, Bytes>,
         vm_traces: Option<bool>,
     ) -> Self {
-        Self {
-
-            hook_address,
-            account_balances,
-            all_tokens,
-            state,
-            attributes,
-            balances,
-            vm_traces,
-        }
+        Self { hook_address, account_balances, all_tokens, state, attributes, balances, vm_traces }
     }
 }
 

--- a/src/evm/protocol/uniswap_v4/hooks/hook_handler_creator.rs
+++ b/src/evm/protocol/uniswap_v4/hooks/hook_handler_creator.rs
@@ -37,6 +37,7 @@ pub struct HookCreationParams<'a> {
 }
 
 impl<'a> HookCreationParams<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         hook_address: Address,
         account_balances: &'a HashMap<Bytes, HashMap<Bytes, Bytes>>,

--- a/src/evm/protocol/uniswap_v4/tycho_decoder.rs
+++ b/src/evm/protocol/uniswap_v4/tycho_decoder.rs
@@ -29,7 +29,7 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for UniswapV4State {
         _block: BlockHeader,
         account_balances: &HashMap<Bytes, HashMap<Bytes, Bytes>>,
         all_tokens: &HashMap<Bytes, Token>,
-        _decoder_context: &DecoderContext,
+        decoder_context: &DecoderContext,
     ) -> Result<Self, Self::Error> {
         let liq = snapshot
             .state
@@ -160,6 +160,7 @@ impl TryFromWithBlock<ComponentWithState, BlockHeader> for UniswapV4State {
                 state.clone(),
                 &merged_attributes,
                 &snapshot.state.balances,
+                decoder_context.vm_traces,
             );
 
             let hook_handler = instantiate_hook_handler(&hook_address, hook_params)?;


### PR DESCRIPTION
Sometimes when the pool manager doesn’t hold many AAA tokens, simulating on a hook might fail.

Since we are simulating only on the before/after swap code directly, this assumes that the user has already transferred the funds into the pool manager. If it is a common token this is usually fine (the pool manager already has a high balance of this token), however sometimes this is not the case and we need to mock the pool managers balance for this token