### PR TITLE
fix: Update block in UniswapV4State and EVMPoolState

### DIFF
--- a/src/evm/protocol/vm/state.rs
+++ b/src/evm/protocol/vm/state.rs
@@ -656,6 +656,33 @@ where
         tokens: &HashMap<Bytes, Token>,
         balances: &Balances,
     ) -> Result<(), TransitionError<String>> {
+        // Update block information if provided in the delta attributes
+        if let Some(block_number_bytes) = delta
+            .updated_attributes
+            .get("block_number")
+        {
+            self.block.number = u64::from_be_bytes(
+                block_number_bytes[block_number_bytes.len() - 8..]
+                    .try_into()
+                    .map_err(|_| {
+                        TransitionError::DecodeError("Invalid block_number bytes".to_string())
+                    })?,
+            );
+        }
+
+        if let Some(block_timestamp_bytes) = delta
+            .updated_attributes
+            .get("block_timestamp")
+        {
+            self.block.timestamp = u64::from_be_bytes(
+                block_timestamp_bytes[block_timestamp_bytes.len() - 8..]
+                    .try_into()
+                    .map_err(|_| {
+                        TransitionError::DecodeError("Invalid block_timestamp bytes".to_string())
+                    })?,
+            );
+        }
+
         if self.manual_updates {
             // Directly check for "update_marker" in `updated_attributes`
             if let Some(marker) = delta
@@ -1229,5 +1256,41 @@ mod tests {
             U256::from(3000000000u64),
             "New token balance should be unchanged"
         );
+    }
+
+    #[tokio::test]
+    async fn test_delta_transition_block_update() {
+        let mut pool_state = setup_pool_state().await;
+
+        let initial_number = pool_state.block.number;
+        let initial_timestamp = pool_state.block.timestamp;
+
+        let new_block_number = initial_number + 1;
+        let new_timestamp = initial_timestamp + 100;
+
+        let attributes: HashMap<String, Bytes> = [
+            ("block_number".to_string(), Bytes::from(new_block_number.to_be_bytes().to_vec())),
+            ("block_timestamp".to_string(), Bytes::from(new_timestamp.to_be_bytes().to_vec())),
+        ]
+        .into_iter()
+        .collect();
+
+        let delta = ProtocolStateDelta {
+            component_id: "test_pool".to_owned(),
+            updated_attributes: attributes,
+            deleted_attributes: HashSet::new(),
+        };
+
+        let mut tokens = HashMap::new();
+        tokens.insert(dai().address, dai());
+        tokens.insert(bal().address, bal());
+        let balances = Balances::default();
+
+        pool_state
+            .delta_transition(delta, &tokens, &balances)
+            .unwrap();
+
+        assert_eq!(pool_state.block.number, new_block_number);
+        assert_eq!(pool_state.block.timestamp, new_timestamp);
     }
 }


### PR DESCRIPTION
- the issue stemmed from UniswapV4State. It's likely not an issue yet in EVMPoolState.
- beforeSwap relies on the block timestamp in the case of Euler. We get an arithmetic over/underflow if this is wrong. For an  example of where this is problematic in the EVault:
```
uint256 deltaT = block.timestamp - vaultCache.lastInterestAccumulatorUpdate;
<=> uint256 deltaT = 1758201863 - 1758201935;
```