### PR TITLE
feat: Add 2, 3 and 4 BIPS fee tiers to uniswap v3

### DIFF
--- a/src/evm/protocol/uniswap_v3/enums.rs
+++ b/src/evm/protocol/uniswap_v3/enums.rs
@@ -1,6 +1,9 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FeeAmount {
     Lowest = 100,      // 0.01%
+    Lowest2 = 200,     // 0.02%
+    Lowest3 = 300,     // 0.03%
+    Lowest4 = 400,     // 0.04%
     Low = 500,         // 0.05%
     MediumLow = 2500,  // 0.25% [Pancakeswap V3]
     Medium = 3000,     // 0.3%
@@ -14,6 +17,9 @@ impl std::convert::TryFrom<i32> for FeeAmount {
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
             100 => Ok(FeeAmount::Lowest),
+            200 => Ok(FeeAmount::Lowest2),
+            300 => Ok(FeeAmount::Lowest3),
+            400 => Ok(FeeAmount::Lowest4),
             500 => Ok(FeeAmount::Low),
             2500 => Ok(FeeAmount::MediumLow),
             3000 => Ok(FeeAmount::Medium),

--- a/src/evm/protocol/uniswap_v3/state.rs
+++ b/src/evm/protocol/uniswap_v3/state.rs
@@ -64,6 +64,9 @@ impl UniswapV3State {
     fn get_spacing(fee: FeeAmount) -> u16 {
         match fee {
             FeeAmount::Lowest => 1,
+            FeeAmount::Lowest2 => 2,
+            FeeAmount::Lowest3 => 3,
+            FeeAmount::Lowest4 => 4,
             FeeAmount::Low => 10,
             FeeAmount::MediumLow => 50,
             FeeAmount::Medium => 60,


### PR DESCRIPTION
Recently these fee tiers were added and are causing decoding failures on Base