### PR TITLE
fix: make sure we don't emit any update after we skipped a decoder failure for a component

### DIFF
--- a/src/evm/engine_db/mod.rs
+++ b/src/evm/engine_db/mod.rs
@@ -68,7 +68,7 @@ where
     Ok(engine)
 }
 
-pub async fn update_engine(
+pub fn update_engine(
     db: PreCachedDB,
     block: Option<BlockHeader>,
     vm_storage: Option<HashMap<Address, ResponseAccount>>,


### PR DESCRIPTION
This fix is very conservative. The idea is simple: if there is a decoding failure and `skip_state_decode_failures` is on, we emit the removal of the pool and make sure we never publish any new state for it (until it restarts). This will help making sure we're not serving wrong state to clients.

Every failure emits a warn so it's easy to catch them and investigate.