### PR TITLE
feat: native Curve StableSwap 2-token pool simulation

### DIFF
--- a/src/evm/protocol/curve_stableswap/decoder.rs
+++ b/src/evm/protocol/curve_stableswap/decoder.rs
@@ -1,0 +1,220 @@
+use std::collections::HashMap;
+
+use alloy::primitives::U256;
+use tycho_client::feed::{synchronizer::ComponentWithState, BlockHeader};
+use tycho_common::{models::token::Token, Bytes};
+
+use super::{math, state::CurveStableSwapState};
+use crate::protocol::{
+    errors::InvalidSnapshotError,
+    models::{DecoderContext, TryFromWithBlock},
+};
+
+impl TryFromWithBlock<ComponentWithState, BlockHeader> for CurveStableSwapState {
+    type Error = InvalidSnapshotError;
+
+    async fn try_from_with_header(
+        snapshot: ComponentWithState,
+        _block: BlockHeader,
+        _account_balances: &HashMap<Bytes, HashMap<Bytes, Bytes>>,
+        all_tokens: &HashMap<Bytes, Token>,
+        _decoder_context: &DecoderContext,
+    ) -> Result<Self, Self::Error> {
+        let attributes = &snapshot.state.attributes;
+
+        let reserve0 = U256::from_be_slice(
+            attributes
+                .get("reserve0")
+                .ok_or(InvalidSnapshotError::MissingAttribute("reserve0".to_string()))?,
+        );
+
+        let reserve1 = U256::from_be_slice(
+            attributes
+                .get("reserve1")
+                .ok_or(InvalidSnapshotError::MissingAttribute("reserve1".to_string()))?,
+        );
+
+        // On-chain A() returns raw A without precision. Internal math requires A * A_PRECISION.
+        let raw_a = U256::from_be_slice(
+            attributes
+                .get("A")
+                .ok_or(InvalidSnapshotError::MissingAttribute("A".to_string()))?,
+        );
+        let amplification = raw_a * math::A_PRECISION;
+
+        let fee = U256::from_be_slice(
+            attributes
+                .get("fee")
+                .ok_or(InvalidSnapshotError::MissingAttribute("fee".to_string()))?,
+        );
+
+        // Token decimals in canonical order (lower address = token0).
+        // This matches how reserve0/reserve1 map to tokens across Tycho.
+        let tokens = &snapshot.component.tokens;
+        if tokens.len() != 2 {
+            return Err(InvalidSnapshotError::MissingAttribute(format!(
+                "expected 2 tokens, got {}",
+                tokens.len()
+            )));
+        }
+
+        let (addr0, addr1) =
+            if tokens[0] < tokens[1] { (&tokens[0], &tokens[1]) } else { (&tokens[1], &tokens[0]) };
+
+        let token0_decimals = all_tokens
+            .get(addr0)
+            .map(|t| t.decimals)
+            .ok_or(InvalidSnapshotError::MissingAttribute("token0 decimals".to_string()))?;
+
+        let token1_decimals = all_tokens
+            .get(addr1)
+            .map(|t| t.decimals)
+            .ok_or(InvalidSnapshotError::MissingAttribute("token1 decimals".to_string()))?;
+
+        let rate0 = math::rate_from_decimals(token0_decimals)
+            .map_err(|e| InvalidSnapshotError::ValueError(e.to_string()))?;
+        let rate1 = math::rate_from_decimals(token1_decimals)
+            .map_err(|e| InvalidSnapshotError::ValueError(e.to_string()))?;
+
+        Ok(CurveStableSwapState::new(reserve0, reserve1, amplification, fee, rate0, rate1))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use alloy::primitives::U256;
+    use tycho_client::feed::{synchronizer::ComponentWithState, BlockHeader};
+    use tycho_common::{
+        dto::{ProtocolComponent as DtoProtocolComponent, ResponseProtocolState},
+        models::{token::Token, Chain},
+        Bytes,
+    };
+
+    use super::super::{math, state::CurveStableSwapState};
+    use crate::protocol::{errors::InvalidSnapshotError, models::TryFromWithBlock};
+
+    fn make_snapshot(
+        attributes: HashMap<String, Bytes>,
+        token_addresses: Vec<Bytes>,
+    ) -> ComponentWithState {
+        ComponentWithState {
+            state: ResponseProtocolState {
+                component_id: "CurvePool".to_owned(),
+                attributes,
+                balances: HashMap::new(),
+            },
+            component: DtoProtocolComponent { tokens: token_addresses, ..Default::default() },
+            component_tvl: None,
+            entrypoints: Vec::new(),
+        }
+    }
+
+    fn dai_address() -> Bytes {
+        Bytes::from(vec![0u8; 20])
+    }
+
+    fn usdc_address() -> Bytes {
+        Bytes::from(vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+    }
+
+    fn all_tokens() -> HashMap<Bytes, Token> {
+        let mut tokens = HashMap::new();
+        tokens.insert(
+            dai_address(),
+            Token::new(&dai_address(), "DAI", 18, 0, &[Some(10_000)], Chain::Ethereum, 100),
+        );
+        tokens.insert(
+            usdc_address(),
+            Token::new(&usdc_address(), "USDC", 6, 0, &[Some(10_000)], Chain::Ethereum, 100),
+        );
+        tokens
+    }
+
+    #[tokio::test]
+    async fn test_decode_snapshot() {
+        let snapshot = make_snapshot(
+            HashMap::from([
+                ("reserve0".to_string(), Bytes::from(U256::from(1_000_000u64).to_be_bytes_vec())),
+                ("reserve1".to_string(), Bytes::from(U256::from(2_000_000u64).to_be_bytes_vec())),
+                ("A".to_string(), Bytes::from(U256::from(50u64).to_be_bytes_vec())),
+                ("fee".to_string(), Bytes::from(U256::from(4_000_000u64).to_be_bytes_vec())),
+            ]),
+            vec![dai_address(), usdc_address()],
+        );
+
+        let result = CurveStableSwapState::try_from_with_header(
+            snapshot,
+            BlockHeader::default(),
+            &HashMap::default(),
+            &all_tokens(),
+            &Default::default(),
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let expected = CurveStableSwapState::new(
+            U256::from(1_000_000u64),
+            U256::from(2_000_000u64),
+            U256::from(50u64) * math::A_PRECISION,
+            U256::from(4_000_000u64),
+            math::rate_from_decimals(18).unwrap(),
+            math::rate_from_decimals(6).unwrap(),
+        );
+        assert_eq!(result.unwrap(), expected);
+    }
+
+    #[tokio::test]
+    async fn test_decode_missing_reserve0() {
+        let snapshot = make_snapshot(
+            HashMap::from([(
+                "reserve1".to_string(),
+                Bytes::from(U256::from(100u64).to_be_bytes_vec()),
+            )]),
+            vec![dai_address(), usdc_address()],
+        );
+
+        let result = CurveStableSwapState::try_from_with_header(
+            snapshot,
+            BlockHeader::default(),
+            &HashMap::default(),
+            &all_tokens(),
+            &Default::default(),
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            InvalidSnapshotError::MissingAttribute(ref x) if x == "reserve0"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_decode_missing_amplification() {
+        let snapshot = make_snapshot(
+            HashMap::from([
+                ("reserve0".to_string(), Bytes::from(U256::from(500u64).to_be_bytes_vec())),
+                ("reserve1".to_string(), Bytes::from(U256::from(600u64).to_be_bytes_vec())),
+                ("fee".to_string(), Bytes::from(U256::from(4_000_000u64).to_be_bytes_vec())),
+            ]),
+            vec![dai_address(), usdc_address()],
+        );
+
+        let result = CurveStableSwapState::try_from_with_header(
+            snapshot,
+            BlockHeader::default(),
+            &HashMap::default(),
+            &all_tokens(),
+            &Default::default(),
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            InvalidSnapshotError::MissingAttribute(ref x) if x == "A"
+        ));
+    }
+}

--- a/src/evm/protocol/curve_stableswap/math.rs
+++ b/src/evm/protocol/curve_stableswap/math.rs
@@ -1,0 +1,267 @@
+//! StableSwap invariant math.
+//!
+//! Newton-Raphson solvers for the Curve StableSwap invariant, ported from Vyper:
+//! <https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/base/SwapTemplateBase.vy>
+//!
+//! All arithmetic uses `U256` and matches the on-chain implementation bit-for-bit.
+use alloy::primitives::U256;
+use tycho_common::simulation::errors::SimulationError;
+
+use crate::evm::protocol::safe_math::{safe_add_u256, safe_div_u256, safe_mul_u256, safe_sub_u256};
+
+/// Number of coins in the pool (this module supports only 2-token pools).
+pub const N_COINS: U256 = U256::from_limbs([2, 0, 0, 0]);
+
+/// Curve uses A_PRECISION = 100 for extra precision on the amplification coefficient.
+pub const A_PRECISION: U256 = U256::from_limbs([100, 0, 0, 0]);
+
+/// Curve fee denominator (10^10).
+pub const FEE_DENOMINATOR: U256 = U256::from_limbs([10_000_000_000, 0, 0, 0]);
+
+/// Compute normalization rate from token decimals: `10^(18 - decimals)`.
+pub fn rate_from_decimals(decimals: u32) -> Result<U256, SimulationError> {
+    let exponent = 18u32
+        .checked_sub(decimals)
+        .ok_or_else(|| {
+            SimulationError::FatalError(format!("Token decimals must be <= 18, got {decimals}"))
+        })?;
+    Ok(U256::from(10u64).pow(U256::from(exponent)))
+}
+
+/// Maximum Newton-Raphson iterations (matches Curve on-chain).
+const MAX_ITERATIONS: usize = 255;
+
+/// Compute the StableSwap invariant D for a 2-token pool.
+///
+/// Uses Newton-Raphson iteration matching Curve's on-chain `get_D()` exactly.
+/// `amp` is the amplification coefficient in internal precision (`A * A_PRECISION`).
+pub fn get_d(x: U256, y: U256, amp: U256) -> Result<U256, SimulationError> {
+    let s = safe_add_u256(x, y)?;
+    if s.is_zero() {
+        return Ok(U256::ZERO);
+    }
+
+    let ann = safe_mul_u256(amp, N_COINS)?;
+
+    let mut d = s;
+    for _ in 0..MAX_ITERATIONS {
+        let d_prev = d;
+
+        // D_P = D * D / (x * N_COINS) * D / (y * N_COINS)
+        let d_p = safe_div_u256(safe_mul_u256(d, d)?, safe_mul_u256(x, N_COINS)?)?;
+        let d_p = safe_div_u256(safe_mul_u256(d_p, d)?, safe_mul_u256(y, N_COINS)?)?;
+
+        // numerator = (Ann * S / A_PRECISION + D_P * N_COINS) * D
+        let numerator = safe_mul_u256(
+            safe_add_u256(
+                safe_div_u256(safe_mul_u256(ann, s)?, A_PRECISION)?,
+                safe_mul_u256(d_p, N_COINS)?,
+            )?,
+            d,
+        )?;
+
+        // denominator = (Ann - A_PRECISION) * D / A_PRECISION + (N_COINS + 1) * D_P
+        let denominator = safe_add_u256(
+            safe_div_u256(safe_mul_u256(safe_sub_u256(ann, A_PRECISION)?, d)?, A_PRECISION)?,
+            safe_mul_u256(safe_add_u256(N_COINS, U256::from(1))?, d_p)?,
+        )?;
+
+        d = safe_div_u256(numerator, denominator)?;
+
+        // Convergence check: |D - D_prev| <= 1
+        let diff = if d > d_prev { d - d_prev } else { d_prev - d };
+        if diff <= U256::from(1) {
+            return Ok(d);
+        }
+    }
+
+    Err(SimulationError::FatalError("get_d did not converge".to_string()))
+}
+
+/// Compute the new balance of one token given the other's new balance and invariant D.
+///
+/// For a 2-token pool: given new x, finds new y (or vice versa — symmetric).
+/// `amp` is the amplification coefficient in internal precision (`A * A_PRECISION`).
+pub fn get_y(x_new: U256, d: U256, amp: U256) -> Result<U256, SimulationError> {
+    let ann = safe_mul_u256(amp, N_COINS)?;
+
+    // c = D * D / (x_new * N_COINS)
+    // c = c * D * A_PRECISION / (Ann * N_COINS)
+    // Matches Vyper multiplication order exactly.
+    let c = safe_div_u256(safe_mul_u256(d, d)?, safe_mul_u256(x_new, N_COINS)?)?;
+    let c = safe_div_u256(
+        safe_mul_u256(safe_mul_u256(c, d)?, A_PRECISION)?,
+        safe_mul_u256(ann, N_COINS)?,
+    )?;
+
+    // b = x_new + D * A_PRECISION / Ann
+    let b = safe_add_u256(x_new, safe_div_u256(safe_mul_u256(d, A_PRECISION)?, ann)?)?;
+
+    let mut y = d;
+    for _ in 0..MAX_ITERATIONS {
+        let y_prev = y;
+
+        // y = (y^2 + c) / (2*y + b - D)
+        let numerator = safe_add_u256(safe_mul_u256(y, y)?, c)?;
+        let denominator = safe_sub_u256(safe_add_u256(safe_mul_u256(y, U256::from(2))?, b)?, d)?;
+        y = safe_div_u256(numerator, denominator)?;
+
+        let diff = if y > y_prev { y - y_prev } else { y_prev - y };
+        if diff <= U256::from(1) {
+            return Ok(y);
+        }
+    }
+
+    Err(SimulationError::FatalError("get_y did not converge".to_string()))
+}
+
+/// Analytical spot price dy/dx for a 2-token StableSwap pool.
+///
+/// Derived from the StableSwap invariant:
+///   dy/dx = (Ann * x + D_p / x) / (Ann * y + D_p / y)
+/// where D_p = D^3 / (4 * x * y).
+///
+/// Returns the marginal price as (numerator, denominator) in U256 to avoid f64 precision loss.
+pub fn spot_price_raw(
+    norm_in: U256,
+    norm_out: U256,
+    d: U256,
+    amp: U256,
+) -> Result<(U256, U256), SimulationError> {
+    let ann = safe_mul_u256(amp, N_COINS)?;
+
+    // D_p = D^3 / (4 * norm_in * norm_out), split to avoid overflow
+    let d_p = safe_div_u256(
+        safe_mul_u256(safe_div_u256(safe_mul_u256(d, d)?, safe_mul_u256(norm_in, N_COINS)?)?, d)?,
+        safe_mul_u256(norm_out, N_COINS)?,
+    )?;
+
+    // dy/dx = (Ann/A_PRECISION * norm_in + D_p) / (Ann/A_PRECISION * norm_out + D_p)
+    let ann_scaled = safe_div_u256(ann, A_PRECISION)?;
+    let numerator = safe_add_u256(safe_mul_u256(ann_scaled, norm_in)?, d_p)?;
+    let denominator = safe_add_u256(safe_mul_u256(ann_scaled, norm_out)?, d_p)?;
+
+    Ok((numerator, denominator))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_d_balanced_pool() {
+        let reserve = U256::from(1_000_000_000_000_000_000_000u128); // 1000 tokens (18 dec)
+        let amp = U256::from(10_000u64); // A=100, A_PRECISION=100
+
+        let d = get_d(reserve, reserve, amp).expect("get_d should converge");
+
+        let expected = reserve * U256::from(2);
+        let diff = if d > expected { d - expected } else { expected - d };
+        assert!(diff <= U256::from(1));
+    }
+
+    #[test]
+    fn get_d_zero() {
+        let d = get_d(U256::ZERO, U256::ZERO, U256::from(10000)).expect("should return 0");
+        assert_eq!(d, U256::ZERO);
+    }
+
+    #[test]
+    fn get_y_roundtrip() {
+        let x = U256::from(1_000_000_000_000_000_000_000_000u128);
+        let y = U256::from(1_000_000_000_000_000_000_000_000u128);
+        let amp = U256::from(10_000u64);
+
+        let d = get_d(x, y, amp).expect("get_d");
+        let x_new = x + U256::from(1_000_000_000_000_000_000_000u128);
+        let y_new = get_y(x_new, d, amp).expect("get_y");
+
+        // y_new should be less than original y (we added to x)
+        assert!(y_new < y);
+    }
+
+    #[test]
+    fn get_d_imbalanced_pool() {
+        let x = U256::from(900_000_000_000_000_000_000_000u128); // 900k
+        let y = U256::from(100_000_000_000_000_000_000_000u128); // 100k
+        let amp = U256::from(10_000u64);
+
+        let d = get_d(x, y, amp).expect("get_d should converge");
+
+        // D should be between sum (1M) and geometric mean * 2 (~600k)
+        let sum = x + y;
+        assert!(d <= sum, "D should not exceed sum of reserves");
+        assert!(d > y, "D should exceed the smaller reserve");
+    }
+
+    #[test]
+    fn get_d_high_amplification() {
+        let x = U256::from(1_000_000_000_000_000_000_000_000u128);
+        let y = U256::from(1_000_000_000_000_000_000_000_000u128);
+        let amp = U256::from(100_000_000u64); // A = 1M
+
+        let d = get_d(x, y, amp).expect("get_d should converge with high A");
+        let expected = x + y;
+        let diff = if d > expected { d - expected } else { expected - d };
+        assert!(diff <= U256::from(1));
+    }
+
+    #[test]
+    fn get_d_low_amplification() {
+        let x = U256::from(1_000_000_000_000_000_000_000_000u128);
+        let y = U256::from(1_000_000_000_000_000_000_000_000u128);
+        let amp = U256::from(100u64); // A = 1
+
+        let d = get_d(x, y, amp).expect("get_d should converge with low A");
+        let sum = x + y;
+        assert!(d <= sum);
+    }
+
+    #[test]
+    fn spot_price_raw_balanced() {
+        let reserve = U256::from(1_000_000_000_000_000_000_000_000u128);
+        let amp = U256::from(10_000u64);
+
+        let d = get_d(reserve, reserve, amp).expect("get_d");
+        let (num, den) = spot_price_raw(reserve, reserve, d, amp).expect("spot_price_raw");
+
+        // For balanced pool, marginal price should be ~1:1
+        // num and den should be equal (or differ by at most 1)
+        let diff = if num > den { num - den } else { den - num };
+        assert!(diff <= U256::from(1), "balanced pool should have 1:1 marginal price, diff={diff}");
+    }
+
+    #[test]
+    fn spot_price_raw_imbalanced() {
+        let x = U256::from(900_000_000_000_000_000_000_000u128); // 900k (abundant)
+        let y = U256::from(100_000_000_000_000_000_000_000u128); // 100k (scarce)
+        let amp = U256::from(10_000u64);
+
+        let d = get_d(x, y, amp).expect("get_d");
+        // dy/dx with norm_in=x (abundant), norm_out=y (scarce)
+        let (num, den) = spot_price_raw(x, y, d, amp).expect("spot_price_raw");
+        // Marginal price should differ from 1:1 for imbalanced pool
+        assert_ne!(num, den, "imbalanced pool should not have 1:1 marginal price");
+    }
+
+    #[test]
+    fn get_y_symmetric() {
+        // get_y should be symmetric: if we solve for y given x, then solve for x given y, we get
+        // back
+        let x = U256::from(1_000_000_000_000_000_000_000_000u128);
+        let y = U256::from(500_000_000_000_000_000_000_000u128);
+        let amp = U256::from(10_000u64);
+
+        let d = get_d(x, y, amp).expect("get_d");
+
+        // Given x, solve for y
+        let y_solved = get_y(x, d, amp).expect("get_y for x");
+        let diff = if y_solved > y { y_solved - y } else { y - y_solved };
+        assert!(diff <= U256::from(1), "get_y should recover y from x, diff={diff}");
+
+        // Given y, solve for x
+        let x_solved = get_y(y, d, amp).expect("get_y for y");
+        let diff = if x_solved > x { x_solved - x } else { x - x_solved };
+        assert!(diff <= U256::from(1), "get_y should recover x from y, diff={diff}");
+    }
+}

--- a/src/evm/protocol/curve_stableswap/mod.rs
+++ b/src/evm/protocol/curve_stableswap/mod.rs
@@ -1,0 +1,11 @@
+//! Curve StableSwap 2-token pool (native implementation)
+//!
+//! Native Rust implementation of the Curve StableSwap invariant for 2-token plain pools
+//! (e.g., DAI/USDC, USDS/USDC). ~100x faster than the VM/revm fallback.
+//!
+//! Reference: <https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/base/SwapTemplateBase.vy>
+mod decoder;
+mod math;
+#[cfg(test)]
+mod on_chain_test;
+pub mod state;

--- a/src/evm/protocol/curve_stableswap/on_chain_test.rs
+++ b/src/evm/protocol/curve_stableswap/on_chain_test.rs
@@ -1,0 +1,220 @@
+//! On-chain verification tests for Curve StableSwap.
+//!
+//! These tests call a real Curve pool on mainnet and compare the output
+//! with our native implementation. Run with:
+//!
+//!   RPC_URL=https://eth-mainnet.alchemyapi.io/v2/YOUR_KEY cargo test -p tycho-simulation -- curve_stableswap::on_chain_test --ignored
+//!
+//! Requires the `evm` feature (enabled by default).
+use std::str::FromStr;
+
+use alloy::{
+    primitives::{Address, U256},
+    providers::ProviderBuilder,
+    sol,
+};
+use num_bigint::BigUint;
+use tycho_common::{
+    models::{token::Token, Chain},
+    simulation::protocol_sim::ProtocolSim,
+    Bytes,
+};
+
+use super::{math, state::CurveStableSwapState};
+
+sol! {
+    #[sol(rpc)]
+    interface ICurvePool {
+        function get_dy(int128 i, int128 j, uint256 dx) external view returns (uint256);
+        function balances(uint256 i) external view returns (uint256);
+        function A() external view returns (uint256);
+        function fee() external view returns (uint256);
+    }
+}
+
+/// FRAX/USDC plain 2-token StableSwap pool on Ethereum mainnet.
+/// FRAX = token0 (18 decimals), USDC = token1 (6 decimals).
+const FRAX_USDC_POOL: &str = "0xDcEF968d416a41Cdac0ED8702fAC8128A64241A2";
+
+fn frax_token() -> Token {
+    Token::new(
+        &Bytes::from_str("0x853d955aCEf822Db058eb8505911ED77F175b99e").unwrap(),
+        "FRAX",
+        18,
+        0,
+        &[Some(10_000)],
+        Chain::Ethereum,
+        100,
+    )
+}
+
+fn usdc_token() -> Token {
+    Token::new(
+        &Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap(),
+        "USDC",
+        6,
+        0,
+        &[Some(10_000)],
+        Chain::Ethereum,
+        100,
+    )
+}
+
+#[tokio::test]
+#[ignore = "requires RPC_URL env var pointing to Ethereum mainnet"]
+async fn verify_against_on_chain_frax_usdc() {
+    let rpc_url = std::env::var("RPC_URL").expect("RPC_URL must be set");
+    let provider = ProviderBuilder::new().connect_http(
+        rpc_url
+            .parse()
+            .expect("invalid RPC_URL"),
+    );
+
+    let pool_address = Address::from_str(FRAX_USDC_POOL).unwrap();
+    let pool = ICurvePool::new(pool_address, &provider);
+
+    // Read on-chain state
+    let reserve0 = pool
+        .balances(U256::from(0))
+        .call()
+        .await
+        .expect("balances(0)");
+    let reserve1 = pool
+        .balances(U256::from(1))
+        .call()
+        .await
+        .expect("balances(1)");
+    let amp = pool.A().call().await.expect("A()");
+    let fee = pool.fee().call().await.expect("fee()");
+
+    println!("On-chain state:");
+    println!("  reserve0 (FRAX): {reserve0}");
+    println!("  reserve1 (USDC): {reserve1}");
+    println!("  A: {amp}");
+    println!("  fee: {fee}");
+
+    // A() returns raw A. Internal math requires A * A_PRECISION.
+    let amp_precise = amp * math::A_PRECISION;
+
+    // Build our native state
+    let state = CurveStableSwapState::new(
+        reserve0,
+        reserve1,
+        amp_precise,
+        fee,
+        math::rate_from_decimals(18).unwrap(),
+        math::rate_from_decimals(6).unwrap(),
+    );
+
+    // Test multiple swap amounts
+    let test_amounts_frax: Vec<U256> = vec![
+        U256::from(1_000_000_000_000_000_000u128),       // 1 FRAX
+        U256::from(1_000_000_000_000_000_000_000u128),   // 1,000 FRAX
+        U256::from(100_000_000_000_000_000_000_000u128), // 100,000 FRAX
+    ];
+
+    println!("\nFRAX -> USDC swaps:");
+    for amount_in in &test_amounts_frax {
+        // On-chain result
+        let on_chain = pool
+            .get_dy(0.into(), 1.into(), *amount_in)
+            .call()
+            .await
+            .expect("get_dy");
+
+        // Our result
+        let our_result = state
+            .get_amount_out(
+                BigUint::from_bytes_be(&amount_in.to_be_bytes::<32>()),
+                &frax_token(),
+                &usdc_token(),
+            )
+            .expect("get_amount_out");
+
+        let our_amount = U256::from_be_slice(&our_result.amount.to_bytes_be());
+        println!("  amount_in={amount_in}, on_chain={on_chain}, ours={our_amount}");
+        assert_eq!(our_amount, on_chain, "Output mismatch for amount_in={amount_in}");
+    }
+
+    // Test reverse direction: USDC -> FRAX
+    let test_amounts_usdc: Vec<U256> = vec![
+        U256::from(1_000_000u128),       // 1 USDC
+        U256::from(1_000_000_000u128),   // 1,000 USDC
+        U256::from(100_000_000_000u128), // 100,000 USDC
+    ];
+
+    println!("\nUSDC -> FRAX swaps:");
+    for amount_in in &test_amounts_usdc {
+        let on_chain = pool
+            .get_dy(1.into(), 0.into(), *amount_in)
+            .call()
+            .await
+            .expect("get_dy");
+
+        let our_result = state
+            .get_amount_out(
+                BigUint::from_bytes_be(&amount_in.to_be_bytes::<32>()),
+                &usdc_token(),
+                &frax_token(),
+            )
+            .expect("get_amount_out");
+
+        let our_amount = U256::from_be_slice(&our_result.amount.to_bytes_be());
+        println!("  amount_in={amount_in}, on_chain={on_chain}, ours={our_amount}");
+        assert_eq!(our_amount, on_chain, "Output mismatch for amount_in={amount_in}");
+    }
+
+    // --- Verify spot_price() ---
+    // For a stablecoin pool, spot price should be in a reasonable range (0.5 - 2.0)
+    let price_frax_in_usdc = state
+        .spot_price(&frax_token(), &usdc_token())
+        .unwrap();
+    let price_usdc_in_frax = state
+        .spot_price(&usdc_token(), &frax_token())
+        .unwrap();
+    println!("\nspot_price:");
+    println!("  FRAX priced in USDC: {price_frax_in_usdc}");
+    println!("  USDC priced in FRAX: {price_usdc_in_frax}");
+    // Prices must be positive and finite
+    assert!(price_frax_in_usdc > 0.0 && price_frax_in_usdc.is_finite());
+    assert!(price_usdc_in_frax > 0.0 && price_usdc_in_frax.is_finite());
+    // Prices should be approximate inverses (within 1% for analytical formula)
+    let product = price_frax_in_usdc * price_usdc_in_frax;
+    println!("  product (should be ~1.0): {product}");
+    assert!(
+        product > 0.99 && product < 1.01,
+        "spot prices should be approximate inverses, product={product}"
+    );
+
+    // --- Verify get_limits() ---
+    let frax_addr = Bytes::from_str("0x853d955aCEf822Db058eb8505911ED77F175b99e").unwrap();
+    let usdc_addr = Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").unwrap();
+
+    let (max_in_frax, max_out_usdc) = state
+        .get_limits(frax_addr.clone(), usdc_addr.clone())
+        .unwrap();
+    let (max_in_usdc, max_out_frax) = state
+        .get_limits(usdc_addr, frax_addr)
+        .unwrap();
+    println!("\nget_limits:");
+    println!("  FRAX->USDC: max_in={max_in_frax}, max_out={max_out_usdc}");
+    println!("  USDC->FRAX: max_in={max_in_usdc}, max_out={max_out_frax}");
+
+    // max_out must not exceed the output reserve
+    let reserve1_biguint = BigUint::from_bytes_be(&reserve1.to_be_bytes::<32>());
+    let reserve0_biguint = BigUint::from_bytes_be(&reserve0.to_be_bytes::<32>());
+    assert!(
+        max_out_usdc <= reserve1_biguint,
+        "max_out USDC ({max_out_usdc}) exceeds reserve1 ({reserve1_biguint})"
+    );
+    assert!(
+        max_out_frax <= reserve0_biguint,
+        "max_out FRAX ({max_out_frax}) exceeds reserve0 ({reserve0_biguint})"
+    );
+
+    // get_amount_out at max_in should succeed (not exceed pool capacity)
+    let result_at_limit = state.get_amount_out(max_in_frax, &frax_token(), &usdc_token());
+    assert!(result_at_limit.is_ok(), "get_amount_out should succeed at max_in");
+
+    println!("\nAll on-chain verifications passed!");
+}

--- a/src/evm/protocol/curve_stableswap/state.rs
+++ b/src/evm/protocol/curve_stableswap/state.rs
@@ -1,0 +1,630 @@
+use std::{any::Any, collections::HashMap};
+
+use alloy::primitives::U256;
+use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
+use tycho_common::{
+    dto::ProtocolStateDelta,
+    models::token::Token,
+    simulation::{
+        errors::{SimulationError, TransitionError},
+        protocol_sim::{Balances, GetAmountOutResult, PoolSwap, ProtocolSim, QueryPoolSwapParams},
+    },
+    Bytes,
+};
+
+use super::math::{self, FEE_DENOMINATOR};
+use crate::evm::protocol::{
+    safe_math::{safe_add_u256, safe_div_u256, safe_mul_u256, safe_sub_u256},
+    u256_num::{biguint_to_u256, u256_to_biguint, u256_to_f64},
+    utils::add_fee_markup,
+};
+
+/// Curve StableSwap 2-token pool state.
+///
+/// Reserves are stored in raw (native) token decimals as received from the indexer.
+/// Normalization to 18 decimals happens internally before invariant math, matching
+/// Curve's on-chain RATES mechanism.
+///
+/// Reference: <https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/base/SwapTemplateBase.vy>
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CurveStableSwapState {
+    reserve0: U256,
+    reserve1: U256,
+    /// Amplification coefficient in internal precision: `A * A_PRECISION` (A_PRECISION=100).
+    /// Note: on-chain `A()` returns `A / A_PRECISION`. Use `_A()` or multiply `A()` by 100.
+    amplification: U256,
+    /// Fee in Curve's FEE_DENOMINATOR (10^10). Example: 4_000_000 = 0.04%.
+    fee: U256,
+    /// Normalization rate for token0: 10^(18 - token0_decimals).
+    rate0: U256,
+    /// Normalization rate for token1: 10^(18 - token1_decimals).
+    rate1: U256,
+}
+
+impl CurveStableSwapState {
+    pub fn new(
+        reserve0: U256,
+        reserve1: U256,
+        amplification: U256,
+        fee: U256,
+        rate0: U256,
+        rate1: U256,
+    ) -> Self {
+        Self { reserve0, reserve1, amplification, fee, rate0, rate1 }
+    }
+
+    /// Normalize reserves to 18-decimal space (Curve RATES).
+    fn normalized_reserves(&self) -> Result<(U256, U256), SimulationError> {
+        Ok((safe_mul_u256(self.reserve0, self.rate0)?, safe_mul_u256(self.reserve1, self.rate1)?))
+    }
+}
+
+#[typetag::serde]
+impl ProtocolSim for CurveStableSwapState {
+    fn fee(&self) -> f64 {
+        u256_to_f64(self.fee).expect("Fee value is safe to convert") / 1e10
+    }
+
+    fn spot_price(&self, base: &Token, quote: &Token) -> Result<f64, SimulationError> {
+        if self.reserve0.is_zero() || self.reserve1.is_zero() {
+            return Err(SimulationError::RecoverableError("No liquidity".to_string()));
+        }
+        let zero_to_one = quote.address < base.address;
+        let (norm_reserve0, norm_reserve1) = self.normalized_reserves()?;
+
+        let d = math::get_d(norm_reserve0, norm_reserve1, self.amplification)?;
+
+        // Analytical marginal price: dy/dx from the StableSwap invariant derivative.
+        // quote is the input token (what you pay), base is what you buy.
+        let (norm_in, norm_out) = if zero_to_one {
+            (norm_reserve0, norm_reserve1)
+        } else {
+            (norm_reserve1, norm_reserve0)
+        };
+        let (num, den) = math::spot_price_raw(norm_in, norm_out, d, self.amplification)?;
+
+        // base_per_quote = num / den (how much base you get per 1 quote)
+        let base_per_quote = u256_to_f64(num)? / u256_to_f64(den)?;
+
+        // Invert: price = quote per base
+        let price = 1.0 / base_per_quote;
+
+        Ok(add_fee_markup(price, self.fee()))
+    }
+
+    fn get_amount_out(
+        &self,
+        amount_in: BigUint,
+        token_in: &Token,
+        token_out: &Token,
+    ) -> Result<GetAmountOutResult, SimulationError> {
+        let amount_in_u256 = biguint_to_u256(&amount_in);
+        if amount_in_u256.is_zero() {
+            return Err(SimulationError::InvalidInput("Amount in cannot be zero".to_string(), None));
+        }
+        if self.reserve0.is_zero() || self.reserve1.is_zero() {
+            return Err(SimulationError::RecoverableError("No liquidity".to_string()));
+        }
+        let zero_to_one = token_in.address < token_out.address;
+
+        let (norm_reserve0, norm_reserve1) = self.normalized_reserves()?;
+        let (rate_in, rate_out) =
+            if zero_to_one { (self.rate0, self.rate1) } else { (self.rate1, self.rate0) };
+        let (norm_in, norm_out) = if zero_to_one {
+            (norm_reserve0, norm_reserve1)
+        } else {
+            (norm_reserve1, norm_reserve0)
+        };
+
+        // Scale input to 18 decimals
+        let amount_in_normalized = safe_mul_u256(amount_in_u256, rate_in)?;
+
+        let d = math::get_d(norm_reserve0, norm_reserve1, self.amplification)?;
+        let x_new = safe_add_u256(norm_in, amount_in_normalized)?;
+        let y_new = math::get_y(x_new, d, self.amplification)?;
+
+        // Curve subtracts 1 wei as safety margin: dy = xp[j] - y - 1
+        let dy_raw = safe_sub_u256(safe_sub_u256(norm_out, y_new)?, U256::from(1))?;
+
+        // Apply fee (in normalized space)
+        let fee_amount = safe_div_u256(safe_mul_u256(dy_raw, self.fee)?, FEE_DENOMINATOR)?;
+        let dy_after_fee = safe_sub_u256(dy_raw, fee_amount)?;
+
+        // Scale output back to token's native decimals
+        let amount_out = safe_div_u256(dy_after_fee, rate_out)?;
+
+        let mut new_state = self.clone();
+        if zero_to_one {
+            new_state.reserve0 = safe_add_u256(self.reserve0, amount_in_u256)?;
+            new_state.reserve1 = safe_sub_u256(self.reserve1, amount_out)?;
+        } else {
+            new_state.reserve0 = safe_sub_u256(self.reserve0, amount_out)?;
+            new_state.reserve1 = safe_add_u256(self.reserve1, amount_in_u256)?;
+        }
+
+        Ok(GetAmountOutResult::new(
+            u256_to_biguint(amount_out),
+            BigUint::from(150_000u32),
+            Box::new(new_state),
+        ))
+    }
+
+    fn get_limits(
+        &self,
+        sell_token: Bytes,
+        buy_token: Bytes,
+    ) -> Result<(BigUint, BigUint), SimulationError> {
+        let zero_to_one = sell_token < buy_token;
+        let (reserve_in, reserve_out) = if zero_to_one {
+            (self.reserve0, self.reserve1)
+        } else {
+            (self.reserve1, self.reserve0)
+        };
+
+        if reserve_in.is_zero() || reserve_out.is_zero() {
+            return Ok((BigUint::ZERO, BigUint::ZERO));
+        }
+
+        // Compute the input amount that would drain ~90% of the output reserve.
+        // This is the actual protocol limit — Curve reverts when output reserve hits 0.
+        let (norm_reserve0, norm_reserve1) = self.normalized_reserves()?;
+        let (rate_in, rate_out) =
+            if zero_to_one { (self.rate0, self.rate1) } else { (self.rate1, self.rate0) };
+        let (norm_in, norm_out) = if zero_to_one {
+            (norm_reserve0, norm_reserve1)
+        } else {
+            (norm_reserve1, norm_reserve0)
+        };
+
+        // Target: output reserve drops to 10% of current (90% drained)
+        let y_target = safe_div_u256(norm_out, U256::from(10))?;
+
+        let d = math::get_d(norm_reserve0, norm_reserve1, self.amplification)?;
+        // get_y is symmetric: given target y, find required x
+        let x_required = math::get_y(y_target, d, self.amplification)?;
+        let max_in_normalized = safe_sub_u256(x_required, norm_in)?;
+
+        // Scale back to native decimals
+        let max_in = safe_div_u256(max_in_normalized, rate_in)?;
+
+        // Compute max_out for this max_in, including fee
+        let dy_raw = safe_sub_u256(norm_out, y_target)?;
+        let fee_amount = safe_div_u256(safe_mul_u256(dy_raw, self.fee)?, FEE_DENOMINATOR)?;
+        let dy_after_fee = safe_sub_u256(dy_raw, fee_amount)?;
+        let max_out = safe_div_u256(dy_after_fee, rate_out)?;
+
+        Ok((u256_to_biguint(max_in), u256_to_biguint(max_out)))
+    }
+
+    fn delta_transition(
+        &mut self,
+        delta: ProtocolStateDelta,
+        _tokens: &HashMap<Bytes, Token>,
+        _balances: &Balances,
+    ) -> Result<(), TransitionError> {
+        self.reserve0 = U256::from_be_slice(
+            delta
+                .updated_attributes
+                .get("reserve0")
+                .ok_or(TransitionError::MissingAttribute("reserve0".to_string()))?,
+        );
+
+        self.reserve1 = U256::from_be_slice(
+            delta
+                .updated_attributes
+                .get("reserve1")
+                .ok_or(TransitionError::MissingAttribute("reserve1".to_string()))?,
+        );
+
+        if let Some(amp_bytes) = delta.updated_attributes.get("A") {
+            self.amplification = U256::from_be_slice(amp_bytes) * math::A_PRECISION;
+        }
+
+        if let Some(fee_bytes) = delta.updated_attributes.get("fee") {
+            self.fee = U256::from_be_slice(fee_bytes);
+        }
+
+        Ok(())
+    }
+
+    fn query_pool_swap(&self, _params: &QueryPoolSwapParams) -> Result<PoolSwap, SimulationError> {
+        Err(SimulationError::InvalidInput(
+            "CurveStableSwapState does not support query_pool_swap yet".to_string(),
+            None,
+        ))
+    }
+
+    fn clone_box(&self) -> Box<dyn ProtocolSim> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn eq(&self, other: &dyn ProtocolSim) -> bool {
+        if let Some(other_state) = other.as_any().downcast_ref::<Self>() {
+            self.reserve0 == other_state.reserve0 &&
+                self.reserve1 == other_state.reserve1 &&
+                self.amplification == other_state.amplification &&
+                self.fee == other_state.fee &&
+                self.rate0 == other_state.rate0 &&
+                self.rate1 == other_state.rate1
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{HashMap, HashSet},
+        str::FromStr,
+    };
+
+    use num_bigint::BigUint;
+    use num_traits::Zero;
+    use tycho_common::{
+        dto::ProtocolStateDelta,
+        hex_bytes::Bytes,
+        models::{token::Token, Chain},
+        simulation::{
+            errors::TransitionError,
+            protocol_sim::{Balances, ProtocolSim},
+        },
+    };
+
+    use super::*;
+
+    fn token_dai() -> Token {
+        Token::new(
+            &Bytes::from_str("0x0000000000000000000000000000000000000000").unwrap(),
+            "DAI",
+            18,
+            0,
+            &[Some(10_000)],
+            Chain::Ethereum,
+            100,
+        )
+    }
+
+    fn token_usdc() -> Token {
+        Token::new(
+            &Bytes::from_str("0x0000000000000000000000000000000000000001").unwrap(),
+            "USDC",
+            6,
+            0,
+            &[Some(10_000)],
+            Chain::Ethereum,
+            100,
+        )
+    }
+
+    /// Balanced pool: 1M DAI (18 dec) + 1M USDC (6 dec)
+    fn balanced_pool() -> CurveStableSwapState {
+        CurveStableSwapState::new(
+            U256::from(1_000_000_000_000_000_000_000_000u128), // 1M DAI in wei
+            U256::from(1_000_000_000_000u128),                 // 1M USDC in 6-dec
+            U256::from(10_000u64),                             // A = 100
+            U256::from(4_000_000u64),                          // 0.04% fee
+            math::rate_from_decimals(18).unwrap(),
+            math::rate_from_decimals(6).unwrap(),
+        )
+    }
+
+    /// Same-decimal pool for simpler math verification
+    fn balanced_pool_same_decimals() -> CurveStableSwapState {
+        CurveStableSwapState::new(
+            U256::from(1_000_000_000_000_000_000_000_000u128),
+            U256::from(1_000_000_000_000_000_000_000_000u128),
+            U256::from(10_000u64),
+            U256::from(4_000_000u64),
+            math::rate_from_decimals(18).unwrap(),
+            math::rate_from_decimals(18).unwrap(),
+        )
+    }
+
+    #[test]
+    fn test_get_amount_out_same_decimals() {
+        let state = balanced_pool_same_decimals();
+        let amount_in = BigUint::from(1_000_000_000_000_000_000_000u128); // 1000 tokens
+
+        let result = state
+            .get_amount_out(amount_in, &token_dai(), &token_usdc())
+            .unwrap();
+
+        let expected_min = BigUint::from(999_000_000_000_000_000_000u128);
+        let expected_max = BigUint::from(1_000_000_000_000_000_000_000u128);
+        assert!(result.amount > expected_min && result.amount < expected_max);
+    }
+
+    #[test]
+    fn test_get_amount_out_different_decimals() {
+        let state = balanced_pool();
+
+        // Swap 1000 DAI (18 dec) for USDC (6 dec)
+        let amount_in = BigUint::from(1_000_000_000_000_000_000_000u128); // 1000 DAI
+        let result = state
+            .get_amount_out(amount_in, &token_dai(), &token_usdc())
+            .unwrap();
+
+        // Should get ~999 USDC (6 decimals)
+        let expected_min = BigUint::from(999_000_000u128); // 999 USDC
+        let expected_max = BigUint::from(1_000_000_000u128); // 1000 USDC
+        assert!(
+            result.amount > expected_min && result.amount < expected_max,
+            "Expected ~999 USDC, got {}",
+            result.amount
+        );
+    }
+
+    #[test]
+    fn test_get_amount_out_usdc_to_dai() {
+        let state = balanced_pool();
+
+        // Swap 1000 USDC (6 dec) for DAI (18 dec)
+        let amount_in = BigUint::from(1_000_000_000u128); // 1000 USDC
+        let result = state
+            .get_amount_out(amount_in, &token_usdc(), &token_dai())
+            .unwrap();
+
+        // Should get ~999 DAI (18 decimals)
+        let expected_min = BigUint::from(999_000_000_000_000_000_000u128);
+        let expected_max = BigUint::from(1_000_000_000_000_000_000_000u128);
+        assert!(
+            result.amount > expected_min && result.amount < expected_max,
+            "Expected ~999 DAI, got {}",
+            result.amount
+        );
+    }
+
+    #[test]
+    fn test_get_amount_out_imbalanced() {
+        let state = CurveStableSwapState::new(
+            U256::from(900_000_000_000_000_000_000_000u128), // 900k DAI
+            U256::from(100_000_000_000u128),                 // 100k USDC
+            U256::from(10_000u64),
+            U256::from(4_000_000u64),
+            math::rate_from_decimals(18).unwrap(),
+            math::rate_from_decimals(6).unwrap(),
+        );
+
+        let amount_in = BigUint::from(10_000_000_000_000_000_000_000u128); // 10k DAI
+        let result = state
+            .get_amount_out(amount_in, &token_dai(), &token_usdc())
+            .unwrap();
+
+        // Swapping abundant token for scarce → slippage, output < 10k USDC
+        assert!(result.amount < BigUint::from(10_000_000_000u128)); // < 10k USDC
+    }
+
+    #[test]
+    fn test_fee() {
+        let state = balanced_pool();
+        let fee = state.fee();
+        assert!((fee - 0.0004).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_spot_price_balanced() {
+        let state = balanced_pool();
+        let price = state
+            .spot_price(&token_dai(), &token_usdc())
+            .unwrap();
+        // Balanced stableswap → price ≈ 1.0
+        assert!((price - 1.0).abs() < 0.01, "Expected price ~1.0, got {}", price);
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let state = balanced_pool_same_decimals();
+        let amount_in = BigUint::from(5_000_000_000_000_000_000_000u128); // 5000
+
+        let result1 = state
+            .get_amount_out(amount_in.clone(), &token_dai(), &token_usdc())
+            .unwrap();
+        let new_state = result1
+            .new_state
+            .as_any()
+            .downcast_ref::<CurveStableSwapState>()
+            .unwrap();
+
+        let result2 = new_state
+            .get_amount_out(result1.amount.clone(), &token_usdc(), &token_dai())
+            .unwrap();
+
+        assert!(result2.amount < amount_in);
+        let min_expected = &amount_in * BigUint::from(99u32) / BigUint::from(100u32);
+        assert!(
+            result2.amount > min_expected,
+            "roundtrip loss too high: got {} back from {}",
+            result2.amount,
+            amount_in
+        );
+    }
+
+    #[test]
+    fn test_symmetry_same_decimals() {
+        let state = balanced_pool_same_decimals();
+        let amount = BigUint::from(1_000_000_000_000_000_000_000u128);
+
+        let out_0_to_1 = state
+            .get_amount_out(amount.clone(), &token_dai(), &token_usdc())
+            .unwrap();
+        let out_1_to_0 = state
+            .get_amount_out(amount.clone(), &token_usdc(), &token_dai())
+            .unwrap();
+
+        assert_eq!(out_0_to_1.amount, out_1_to_0.amount);
+    }
+
+    #[test]
+    fn test_delta_transition() {
+        let mut state = balanced_pool();
+        let attributes: HashMap<String, Bytes> = vec![
+            ("reserve0".to_string(), Bytes::from(U256::from(2_000_000u64).to_be_bytes_vec())),
+            ("reserve1".to_string(), Bytes::from(U256::from(3_000_000u64).to_be_bytes_vec())),
+        ]
+        .into_iter()
+        .collect();
+
+        let delta = ProtocolStateDelta {
+            component_id: "State1".to_owned(),
+            updated_attributes: attributes,
+            deleted_attributes: HashSet::new(),
+        };
+
+        let result = state.delta_transition(delta, &HashMap::new(), &Balances::default());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_delta_transition_missing_attribute() {
+        let mut state = balanced_pool();
+        let attributes: HashMap<String, Bytes> =
+            vec![("reserve0".to_string(), Bytes::from(U256::from(1500u64).to_be_bytes_vec()))]
+                .into_iter()
+                .collect();
+
+        let delta = ProtocolStateDelta {
+            component_id: "State1".to_owned(),
+            updated_attributes: attributes,
+            deleted_attributes: HashSet::new(),
+        };
+
+        let result = state.delta_transition(delta, &HashMap::new(), &Balances::default());
+        assert!(result.is_err());
+        match result {
+            Err(TransitionError::MissingAttribute(attr)) => assert_eq!(attr, "reserve1"),
+            _ => panic!("Expected MissingAttribute error"),
+        }
+    }
+
+    #[test]
+    fn test_delta_transition_updates_amplification() {
+        let mut state = balanced_pool();
+        let attributes: HashMap<String, Bytes> = vec![
+            ("reserve0".to_string(), Bytes::from(state.reserve0.to_be_bytes_vec())),
+            ("reserve1".to_string(), Bytes::from(state.reserve1.to_be_bytes_vec())),
+            ("A".to_string(), Bytes::from(U256::from(200u64).to_be_bytes_vec())),
+        ]
+        .into_iter()
+        .collect();
+
+        let delta = ProtocolStateDelta {
+            component_id: "State1".to_owned(),
+            updated_attributes: attributes,
+            deleted_attributes: HashSet::new(),
+        };
+
+        state
+            .delta_transition(delta, &HashMap::new(), &Balances::default())
+            .unwrap();
+        assert_eq!(state.amplification, U256::from(200u64) * super::math::A_PRECISION);
+    }
+
+    #[test]
+    fn test_get_limits_dai_to_usdc() {
+        // DAI (18 dec) → USDC (6 dec), balanced 1M each
+        let state = balanced_pool();
+        let dai = Bytes::from_str("0x0000000000000000000000000000000000000000").unwrap();
+        let usdc = Bytes::from_str("0x0000000000000000000000000000000000000001").unwrap();
+
+        let (max_in, max_out) = state
+            .get_limits(dai.clone(), usdc.clone())
+            .unwrap();
+
+        // max_in should be in DAI decimals (18), significantly more than reserve
+        assert!(max_in > BigUint::ZERO);
+        // max_out should be in USDC decimals (6), close to 90% of 1M USDC
+        let usdc_900k = BigUint::from(900_000_000_000u128); // 900k USDC
+        assert!(
+            max_out > usdc_900k / BigUint::from(2u32),
+            "max_out should be substantial, got {}",
+            max_out
+        );
+
+        // Verify get_amount_out works at max_in
+        let result = state.get_amount_out(max_in, &token_dai(), &token_usdc());
+        assert!(result.is_ok(), "get_amount_out should succeed at max_in");
+    }
+
+    #[test]
+    fn test_get_limits_usdc_to_dai() {
+        // USDC (6 dec) → DAI (18 dec)
+        let state = balanced_pool();
+        let dai = Bytes::from_str("0x0000000000000000000000000000000000000000").unwrap();
+        let usdc = Bytes::from_str("0x0000000000000000000000000000000000000001").unwrap();
+
+        let (max_in, max_out) = state.get_limits(usdc, dai).unwrap();
+
+        // max_in should be in USDC decimals (6)
+        assert!(max_in > BigUint::ZERO);
+        // max_out should be in DAI decimals (18)
+        let dai_900k = BigUint::from(900_000_000_000_000_000_000_000u128); // 900k DAI
+        assert!(
+            max_out > dai_900k / BigUint::from(2u32),
+            "max_out should be substantial, got {}",
+            max_out
+        );
+
+        // Verify get_amount_out works at max_in
+        let result = state.get_amount_out(max_in, &token_usdc(), &token_dai());
+        assert!(result.is_ok(), "get_amount_out should succeed at max_in");
+    }
+
+    #[test]
+    fn test_get_limits_empty_pool() {
+        let state = CurveStableSwapState::new(
+            U256::ZERO,
+            U256::ZERO,
+            U256::from(10_000u64),
+            U256::from(4_000_000u64),
+            math::rate_from_decimals(18).unwrap(),
+            math::rate_from_decimals(6).unwrap(),
+        );
+        let t0 = Bytes::from_str("0x0000000000000000000000000000000000000000").unwrap();
+        let t1 = Bytes::from_str("0x0000000000000000000000000000000000000001").unwrap();
+
+        let (max_in, max_out) = state.get_limits(t0, t1).unwrap();
+        assert!(max_in.is_zero());
+        assert!(max_out.is_zero());
+    }
+
+    #[test]
+    fn test_clone_box_and_eq() {
+        let state = balanced_pool();
+        let cloned = state.clone_box();
+        assert!(ProtocolSim::eq(&state, cloned.as_ref()));
+    }
+
+    #[test]
+    fn test_new_state_is_immutable() {
+        let state = balanced_pool();
+        let original_r0 = state.reserve0;
+        let original_r1 = state.reserve1;
+
+        let _ = state.get_amount_out(
+            BigUint::from(1_000_000_000_000_000_000_000u128),
+            &token_dai(),
+            &token_usdc(),
+        );
+
+        assert_eq!(state.reserve0, original_r0);
+        assert_eq!(state.reserve1, original_r1);
+    }
+
+    #[test]
+    fn test_zero_amount_returns_err() {
+        let state = balanced_pool();
+        assert!(state
+            .get_amount_out(BigUint::ZERO, &token_dai(), &token_usdc())
+            .is_err());
+    }
+}

--- a/src/evm/protocol/mod.rs
+++ b/src/evm/protocol/mod.rs
@@ -2,6 +2,7 @@ pub mod aerodrome_slipstreams;
 mod clmm;
 pub mod cowamm;
 mod cpmm;
+pub mod curve_stableswap;
 pub mod ekubo;
 pub mod ekubo_v3;
 pub mod erc4626;


### PR DESCRIPTION
## Summary

Native Rust implementation of the Curve StableSwap invariant for 2-token plain pools (e.g., DAI/USDC, FRAX/USDC, USDS/USDC). This replaces the VM/revm fallback for these pool types, providing ~100x faster swap simulation.

## Motivation

StableSwap pools are among the highest-volume DeFi pools. The current VM fallback executes Curve bytecode in revm at ~100-200μs per simulation. A native implementation runs at ~900ns (benchmarked in a separate project), enabling significantly better routing performance when evaluating thousands of pool candidates.

## Implementation

**Math (`math.rs`):**
- `get_d()` — Newton-Raphson solver for StableSwap invariant D
- `get_y()` — Newton-Raphson solver for output balance given input and D
- `spot_price_raw()` — Analytical marginal price from invariant derivative (no simulation needed)
- All arithmetic ported line-by-line from [Curve's Vyper source](https://github.com/curvefi/curve-contract/blob/master/contracts/pool-templates/base/SwapTemplateBase.vy), matching multiplication order for bit-for-bit identical results

**State (`state.rs`):**
- `ProtocolSim` implementation with `get_amount_out`, `spot_price`, `get_limits`, `delta_transition`
- Reserves stored in raw (native) token decimals; normalized to 18 decimals internally via rates (matching Curve's RATES mechanism)
- Handles mixed-decimal pairs (e.g., DAI 18-dec / USDC 6-dec)

**Decoder (`decoder.rs`):**
- Decodes `reserve0`, `reserve1`, `A`, `fee` from indexer attributes
- Extracts token decimals from `all_tokens` for rate computation
- Converts raw `A()` to internal precision (`A * A_PRECISION`)

## Verification

**On-chain verification** against FRAX/USDC pool (`0xDcEF968d416a41Cdac0ED8702fAC8128A64241A2`) on Ethereum mainnet:
- 6 swap amounts tested (both directions: FRAX→USDC and USDC→FRAX)
- All `assert_eq!` — **bit-for-bit identical** to on-chain `get_dy()`, zero difference

**30 unit tests** covering:
- Math convergence (balanced, imbalanced, high/low A, symmetry)
- Spot price (balanced pool, imbalanced, inverse property)
- Swap amounts (same decimals, mixed decimals, both directions, imbalanced)
- Delta transitions (reserves, amplification, missing attributes)
- Limits (both directions, empty pool, max_out ≤ reserve)
- Roundtrip consistency, state immutability

## Usage

```rust
.exchange::<CurveStableSwapState>("curve_stableswap", filter, None)
```

## Scope & Limitations

- **2-token plain pools only** — MetaPools and Tricrypto are separate invariants
- **Requires parsed attributes** from indexer (`reserve0`, `reserve1`, `A`, `fee`). The current Curve substreams module may send raw storage slots for the VM adapter instead. An indexer update to emit parsed attributes would be needed.
- `query_pool_swap` not yet implemented (returns error, consistent with V4/VM)

## Follow-up

- MetaPool support (nested pool resolution)
- N-token plain pool generalization
- `query_pool_swap` implementation for target-price solving